### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   sync:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/abhimehro/ctrld-sync/security/code-scanning/1](https://github.com/abhimehro/ctrld-sync/security/code-scanning/1)

In general, to fix this problem you add an explicit `permissions` block at either the workflow root or inside each job. This block should grant only the minimal scopes actually needed by the job (principle of least privilege). If the job doesn’t need to modify repository contents or metadata using `GITHUB_TOKEN`, you can usually restrict it to `contents: read` or even set `permissions: {}` to fully disable the token.

For this specific workflow, all visible steps operate on the local checkout and use a separate secret `TOKEN` and `PROFILE` to run `main.py`. Nothing in the shown YAML requires `GITHUB_TOKEN` write access, and it may not need `GITHUB_TOKEN` at all. A safe, minimal change is to add a `permissions` block at the job level for `sync`, setting `contents: read`. This aligns with the CodeQL suggestion and avoids altering any steps. Concretely, in `.github/workflows/sync.yml`, between `sync:` (line 10) and `runs-on: ubuntu-latest` (line 11), insert:

```yaml
    permissions:
      contents: read
```

No additional imports, methods, or definitions are required; it is a pure YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
