### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/abhimehro/ctrld-sync/security/code-scanning/2](https://github.com/abhimehro/ctrld-sync/security/code-scanning/2)

To fix the problem, add an explicit `permissions:` block that restricts the `GITHUB_TOKEN` to the least privileges required. In this workflow, the job checks out code, sets up Python, installs dependencies, runs a dry-run command, and uploads an artifact; none of these require write access to repository contents or other privileged scopes. Therefore, the minimal and appropriate permission is `contents: read`.

The single best fix without changing existing functionality is to define `permissions: contents: read` at the workflow (top) level so it applies to all jobs (currently just `dry-run`). This is done by inserting:

```yaml
permissions:
  contents: read
```

between the `name: CI` and the `on:` block in `.github/workflows/ci.yml`. No imports, methods, or additional definitions are needed because this is purely a configuration change in the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
