### PR TITLE
🎨 Palette: Smart Profile ID Extraction from URLs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-24 - Fail Fast & Friendly
 **Learning:** In CLI tools involving APIs, cascade failures (hundreds of "Failed to X") caused by basic auth issues (401/403) are overwhelming and confusing. A dedicated "Pre-flight Check" that validates credentials *before* attempting the main workload allows for specific, actionable error messages (e.g. "Check your token at [URL]") instead of generic HTTP errors.
 **Action:** Implement a `check_api_access()` step at the start of any CLI workflow to validate permissions and provide human-readable guidance on failure.
+
+## 2024-05-25 - Smart Input Extraction
+**Learning:** Users often copy full URLs instead of specific IDs because it's easier and they lack context on what exactly defines the "ID". Accepting the full URL and extracting the ID programmatically prevents validation errors and reduces user friction.
+**Action:** When asking for an ID that is part of a URL, accept the full URL and extract the ID automatically using regex.

--- a/test_main.py
+++ b/test_main.py
@@ -319,3 +319,62 @@ def test_check_api_access_network_error(monkeypatch):
     assert m.check_api_access(mock_client, "profile") is False
     assert mock_log.error.called
     assert "Network failure" in str(mock_log.error.call_args)
+
+# Case 8: extract_profile_id correctly extracts ID from URL or returns input
+def test_extract_profile_id():
+    # Regular ID
+    assert main.extract_profile_id("12345") == "12345"
+    # URL with /filters
+    assert main.extract_profile_id("https://controld.com/dashboard/profiles/12345/filters") == "12345"
+    # URL without /filters
+    assert main.extract_profile_id("https://controld.com/dashboard/profiles/12345") == "12345"
+    # URL with params
+    assert main.extract_profile_id("https://controld.com/dashboard/profiles/12345?foo=bar") == "12345"
+    # Clean up whitespace
+    assert main.extract_profile_id("  12345  ") == "12345"
+    # Invalid input returns as is (cleaned)
+    assert main.extract_profile_id("random-string") == "random-string"
+    # Empty input
+    assert main.extract_profile_id("") == ""
+    assert main.extract_profile_id(None) == ""
+
+# Case 9: Interactive input handles URL pasting
+def test_interactive_input_extracts_id(monkeypatch, capsys):
+    # Ensure environment is clean
+    monkeypatch.delenv("PROFILE", raising=False)
+    monkeypatch.delenv("TOKEN", raising=False)
+
+    # Reload main with isatty=True
+    m = reload_main_with_env(monkeypatch, isatty=True)
+    monkeypatch.setattr('sys.stdin.isatty', lambda: True)
+
+    # Provide URL as input
+    url_input = "https://controld.com/dashboard/profiles/extracted_id/filters"
+    monkeypatch.setattr('builtins.input', lambda prompt="": url_input)
+    monkeypatch.setattr('getpass.getpass', lambda prompt="": "test_token")
+
+    # Mock parse_args
+    mock_args = MagicMock()
+    mock_args.profiles = None
+    mock_args.folder_url = None
+    mock_args.dry_run = False
+    mock_args.no_delete = False
+    mock_args.plan_json = None
+    monkeypatch.setattr(m, "parse_args", lambda: mock_args)
+
+    # Mock sync_profile to catch the call
+    mock_sync = MagicMock(return_value=True)
+    monkeypatch.setattr(m, "sync_profile", mock_sync)
+    monkeypatch.setattr(m, "warm_up_cache", MagicMock())
+
+    # Run main, expect clean exit
+    with pytest.raises(SystemExit):
+        m.main()
+
+    # Verify sync_profile called with extracted ID
+    args, _ = mock_sync.call_args
+    assert args[0] == "extracted_id"
+
+    # Verify prompt text update
+    captured = capsys.readouterr()
+    assert "(or just paste the URL)" in captured.out


### PR DESCRIPTION
🎨 Palette: Smart Profile ID Extraction

💡 What:
Added smart extraction logic that allows users to paste the full Control D Dashboard URL (e.g., `https://controld.com/dashboard/profiles/12345/filters`) when prompted for a Profile ID. The system automatically extracts the ID (`12345`) and proceeds.

🎯 Why:
Users often copy the full URL from their browser address bar. Previously, this caused a validation error because the script expected only the alphanumeric ID. This change removes that friction and prevents manual copy-paste errors.

♿ Accessibility/UX:
- Reduces cognitive load (no need to identify where the ID starts/ends).
- Provides immediate success instead of an error message for a common user behavior.
- Updated prompt text clearly states "or just paste the URL".

---
*PR created automatically by Jules for task [4363998502891798168](https://jules.google.com/task/4363998502891798168) started by @abhimehro*