### PR TITLE
🎨 Palette: Add progress bar for fetching existing rules

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,9 @@
+## PALETTE'S JOURNAL - CRITICAL LEARNINGS ONLY
+
+This journal is for recording critical UX/accessibility learnings.
+
+---
+
+## 2024-05-23 - CLI Progress Bars in Parallel Operations
+**Learning:** Adding visual feedback (progress bars) to parallel operations (like `ThreadPoolExecutor`) requires careful management of `stderr`. Standard logging (`logging.warning`) can interfere with `\r` carriage returns used for progress bars.
+**Action:** Always clear the line (`\r\033[K`) before logging warnings inside a progress-tracked loop, and redraw the progress bar afterwards if necessary.


### PR DESCRIPTION
💡 What: Added a progress bar to the `get_all_existing_rules` function and removed a duplicate `render_progress_bar` definition.
🎯 Why: Users had no visual feedback when the script was fetching existing rules from multiple folders, which could take time.
📸 Before/After: Before: Static "Wait..." (or nothing). After: Progress bar "🔍 Fetching existing rules: [██░░] 50%"


---
*PR created automatically by Jules for task [17720429687181325290](https://jules.google.com/task/17720429687181325290) started by @abhimehro*