### PR TITLE
🎨 Palette: Add progress bar for fetching existing rules

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,9 @@
+# Palette's Journal
+
+## 2024-10-24 - Progress Bar in Parallel Tasks
+**Learning:** When using `concurrent.futures`, standard logging can interfere with progress bars. The `render_progress_bar` implementation relies on `\r` to overwrite the line, but if another thread logs to stderr/stdout, it can break the visual.
+**Action:** Always wrap logging calls inside the parallel loop with a line-clearing sequence (`\r\033[K`) if a progress bar is active.
+
+## 2024-10-24 - Duplicate Function Definitions
+**Learning:** Duplicate function definitions in Python (later overwrites earlier) can be confusing for static analysis or human reviewers, even if the runtime behavior is well-defined.
+**Action:** Always scan for and remove duplicate definitions when refactoring to avoid confusion.

--- a/main.py
+++ b/main.py
@@ -159,23 +159,6 @@ def sanitize_for_log(text: Any) -> str:
     return safe
 
 
-def render_progress_bar(
-    current: int, total: int, label: str, prefix: str = "🚀"
-) -> None:
-    if not USE_COLORS or total == 0:
-        return
-
-    width = 20
-    progress = min(1.0, current / total)
-    filled = int(width * progress)
-    bar = "█" * filled + "░" * (width - filled)
-    percent = int(progress * 100)
-
-    # Use \033[K to clear line residue
-    sys.stderr.write(
-        f"\r\033[K{Colors.CYAN}{prefix} {label}: [{bar}] {percent}% ({current}/{total}){Colors.ENDC}"
-    )
-    sys.stderr.flush()
 
 
 def countdown_timer(seconds: int, message: str = "Waiting") -> None:
@@ -677,6 +660,10 @@ def get_all_existing_rules(
 
         # Parallelize fetching rules from folders.
         # Using 5 workers to be safe with rate limits, though GETs are usually cheaper.
+        total_folders = len(folders)
+        completed_folders = 0
+        render_progress_bar(0, total_folders, "Fetching existing rules", prefix="🔍")
+
         with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
             future_to_folder = {
                 executor.submit(_fetch_folder_rules, folder_id): folder_id
@@ -684,13 +671,27 @@ def get_all_existing_rules(
             }
 
             for future in concurrent.futures.as_completed(future_to_folder):
+                completed_folders += 1
                 try:
                     result = future.result()
                     if result:
                         all_rules.update(result)
                 except Exception as e:
+                    if USE_COLORS:
+                        # Clear line to print warning cleanly
+                        sys.stderr.write("\r\033[K")
+                        sys.stderr.flush()
+
                     folder_id = future_to_folder[future]
                     log.warning(f"Failed to fetch rules for folder ID {folder_id}: {e}")
+
+                render_progress_bar(
+                    completed_folders, total_folders, "Fetching existing rules", prefix="🔍"
+                )
+
+        if USE_COLORS:
+            sys.stderr.write(f"\r\033[K")
+            sys.stderr.flush()
 
         log.info(f"Total existing rules across all folders: {len(all_rules)}")
         return all_rules


### PR DESCRIPTION
🎨 Palette: Add progress bar for fetching existing rules

💡 **What:** Added a progress bar to the `get_all_existing_rules` function and removed a duplicate function definition.
🎯 **Why:** Fetching rules from many folders can take time. Users were left with a static screen and no feedback. The progress bar improves perceived performance and provides reassurance.
📸 **Before/After:**
Before:
```
Total existing rules across all folders: 1234
```
After:
```
🔍 Fetching existing rules: [██████████░░░░░] 66% (10/15)
Total existing rules across all folders: 1234
```
♿ **Accessibility:** Uses standard terminal output, compatible with screen readers that handle dynamic updates (though mainly visual). Added line clearing to ensure clean output.

---
*PR created automatically by Jules for task [2834881192475199462](https://jules.google.com/task/2834881192475199462) started by @abhimehro*