### PR TITLE
🛡️ Sentinel: Redact credentials from URLs in logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-23 - URL Credential Leakage in Logs
+**Vulnerability:** `sanitize_for_log` only redacted the API token but allowed URLs containing Basic Auth credentials (e.g. `https://user:pass@host`) to be logged in plain text.
+**Learning:** Sanitization functions often focus on known secrets (like specific tokens) but miss pattern-based leaks like standard URI credentials.
+**Prevention:** Always scrub user:password combinations from any URL before logging. Use regex or URL parsing libraries to identifying and redact the authority section.

--- a/main.py
+++ b/main.py
@@ -151,6 +151,11 @@ def sanitize_for_log(text: Any) -> str:
     s = str(text)
     if TOKEN and TOKEN in s:
         s = s.replace(TOKEN, "[REDACTED]")
+
+    # Redact credentials in URLs (e.g. https://user:pass@host)
+    # Pattern: scheme://user:pass@host -> scheme://[REDACTED]@host
+    s = re.sub(r"(https?://)[^/\s@]+@([^/\s]+)", r"\1[REDACTED]@\2", s)
+
     # repr() safely escapes control characters (e.g., \n -> \\n, \x1b -> \\x1b)
     # This prevents log injection and terminal hijacking.
     safe = repr(s)


### PR DESCRIPTION
**Vulnerability:** URLs containing Basic Auth credentials (e.g., `https://user:password@example.com`) were logged in plain text by `sanitize_for_log`, exposing sensitive information if a user provided such a URL (e.g. via `FOLDER_URLS`).

**Fix:** Updated `sanitize_for_log` in `main.py` to use a regular expression that identifies and replaces the credential part of HTTP/HTTPS URLs with `[REDACTED]`.

**Verification:**
- Confirmed that `https://user:password@host` is logged as `https://[REDACTED]@host`.
- Ran existing tests (`uv run pytest`) to ensure no regressions.
- Verified that `re` module is imported (it was already).

---
*PR created automatically by Jules for task [3352341414052035153](https://jules.google.com/task/3352341414052035153) started by @abhimehro*