### PR TITLE
🛡️ Sentinel: [HIGH] Fix RTLO Spoofing in Folder Names

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-18 - [RTLO/Bidi Spoofing in Folder Names]
+**Vulnerability:** Input validation for folder names allowed Unicode Bidi control characters (e.g., `\u202e`), enabling Homograph/Spoofing attacks (RTLO).
+**Learning:** Standard "printable" checks (`isprintable()`) do not block Bidi control characters, which can be used to mislead users about file extensions or content types.
+**Prevention:** Explicitly block known Bidi control characters (U+202A-U+202E, U+2066-U+2069) in user-visible strings.

--- a/main.py
+++ b/main.py
@@ -444,7 +444,26 @@ def is_valid_folder_name(name: str) -> bool:
     # Block XSS and HTML injection characters
     # Allow: ( ) [ ] { } for folder names (e.g. "Work (Private)")
     dangerous_chars = set("<>\"'`")
-    if any(c in dangerous_chars for c in name):
+
+    # Block path separators to prevent confusion
+    dangerous_chars.update(["/", "\\"])
+
+    # Block Bidi control characters to prevent RTLO spoofing
+    # \u202a (LRE), \u202b (RLE), \u202c (PDF), \u202d (LRO), \u202e (RLO)
+    # \u2066 (LRI), \u2067 (RLI), \u2068 (FSI), \u2069 (PDI)
+    bidi_chars = {
+        "\u202a",
+        "\u202b",
+        "\u202c",
+        "\u202d",
+        "\u202e",
+        "\u2066",
+        "\u2067",
+        "\u2068",
+        "\u2069",
+    }
+
+    if any(c in dangerous_chars or c in bidi_chars for c in name):
         return False
 
     return True

--- a/tests/test_folder_validation.py
+++ b/tests/test_folder_validation.py
@@ -39,5 +39,21 @@ def test_folder_name_security():
         empty_data = {"group": {"group": "   "}}
         assert main.validate_folder_data(empty_data, "http://empty.com") is False
 
+        # Case 6: Path Separators
+        slash_data = {"group": {"group": "Folder/Name"}}
+        assert main.validate_folder_data(slash_data, "http://slash.com") is False
+
+        backslash_data = {"group": {"group": "Folder\\Name"}}
+        assert main.validate_folder_data(backslash_data, "http://backslash.com") is False
+
+        # Case 7: Bidi Control Characters (RTLO)
+        # \u202e is Right-To-Left Override
+        rtlo_data = {"group": {"group": "SafeName\u202eexe.pdf"}}
+        assert main.validate_folder_data(rtlo_data, "http://rtlo.com") is False
+
+        # Case 8: Other Bidi Char
+        lre_data = {"group": {"group": "Name\u202a"}}
+        assert main.validate_folder_data(lre_data, "http://lre.com") is False
+
     finally:
         main.log = original_log


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Folder names allowed Unicode Bidi control characters (e.g., RTLO), enabling Homograph/Spoofing attacks where a name like "safe\u202eexe.pdf" renders as "safepdf.exe". Also allowed path separators / and \ which could cause confusion.
🔧 Fix: Enhanced is_valid_folder_name to explicitly block Bidi control characters and path separators.
✅ Verification: Added new test cases in tests/test_folder_validation.py which pass.

---
*PR created automatically by Jules for task [15718768312849110796](https://jules.google.com/task/15718768312849110796) started by @abhimehro*