### PR TITLE
🎨 Palette: Improve missing dependency error

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,5 @@
+# Palette's Journal
+
+## 2025-05-15 - CLI Dependency Experience
+**Learning:** Users often run scripts directly (`python main.py`) without setting up the environment, leading to intimidating traceback errors (`ModuleNotFoundError`).
+**Action:** Wrap external imports in `try/except` blocks to provide friendly, actionable instructions (e.g., "Please run `uv sync`") instead of raw stack traces.

--- a/main.py
+++ b/main.py
@@ -30,8 +30,16 @@ from functools import lru_cache
 from typing import Any, Callable, Dict, List, Optional, Sequence, Set
 from urllib.parse import urlparse
 
-import httpx
-from dotenv import load_dotenv
+try:
+    import httpx
+    from dotenv import load_dotenv
+except ImportError:
+    # Use raw ANSI codes for simple, dependency-free coloring
+    sys.stderr.write("\033[91m❌ Error: Missing dependencies.\033[0m\n")
+    sys.stderr.write("Please run:\n")
+    sys.stderr.write("  \033[1muv sync\033[0m\n")
+    sys.exit(1)
+
 
 # --------------------------------------------------------------------------- #
 # 0. Bootstrap – load secrets and configure logging


### PR DESCRIPTION
🎨 **Palette: Improve missing dependency error**

💡 **What:**
Wrapped `httpx` and `python-dotenv` imports in `main.py` with a `try/except ImportError` block.

🎯 **Why:**
Users running the script directly (`python main.py`) without setting up the environment encounter a raw `ModuleNotFoundError`. This change intercepts that error and provides a clear instruction to run `uv sync`.

📸 **Before:**
```
Traceback (most recent call last):
  File "main.py", line 30, in <module>
    import httpx
ModuleNotFoundError: No module named 'httpx'
```

📸 **After:**
```
❌ Error: Missing dependencies.
Please run:
  uv sync
```

♿ **Accessibility:**
Improved CLI accessibility by making error messages readable and actionable.

---
*PR created automatically by Jules for task [12942988716419053347](https://jules.google.com/task/12942988716419053347) started by @abhimehro*