### PR TITLE
🛡️ Sentinel: [SECURITY] Enforce secure URL validation and file permissions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel's Journal
+
+## 2025-02-07 - Secure File Creation Pattern
+**Vulnerability:** Default `open()` creates files with user umask, which might allow group/world read access for sensitive files like `plan.json`.
+**Learning:** Python's `open()` mode `w` respects `umask` but doesn't enforce restrictive permissions by default. `os.chmod` after creation leaves a small race condition window.
+**Prevention:** Use `os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)` to create the file descriptor with correct permissions atomically, then wrap with `os.fdopen()`.


### PR DESCRIPTION
Refined `validate_folder_url` to reject URLs with credentials (user:pass@host) to prevent accidental leakage. Secured `plan.json` creation using `os.open` with `0o600` permissions to prevent unauthorized access. Added comprehensive tests in `test_main.py`.

---
*PR created automatically by Jules for task [17198079295871683585](https://jules.google.com/task/17198079295871683585) started by @abhimehro*