### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing input validation on external JSON data

### DIFF
--- a/main.py
+++ b/main.py
@@ -1112,6 +1112,30 @@ def validate_folder_data(data: Dict[str, Any], url: str) -> bool:
         )
         return False
 
+    # Validate 'rules' if present (must be a list)
+    if "rules" in data and not isinstance(data["rules"], list):
+        log.error(f"Invalid data from {sanitize_for_log(url)}: 'rules' must be a list.")
+        return False
+
+    # Validate 'rule_groups' if present (must be a list of dicts)
+    if "rule_groups" in data:
+        if not isinstance(data["rule_groups"], list):
+            log.error(
+                f"Invalid data from {sanitize_for_log(url)}: 'rule_groups' must be a list."
+            )
+            return False
+        for i, rg in enumerate(data["rule_groups"]):
+            if not isinstance(rg, dict):
+                log.error(
+                    f"Invalid data from {sanitize_for_log(url)}: rule_groups[{i}] must be an object."
+                )
+                return False
+            if "rules" in rg and not isinstance(rg["rules"], list):
+                log.error(
+                    f"Invalid data from {sanitize_for_log(url)}: rule_groups[{i}].rules must be a list."
+                )
+                return False
+
     return True
 
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The application processes external JSON data (from URLs) without validating that `rules` is a list and `rule_groups` is a list of dictionaries. This can lead to crashes (DoS) if malformed data is encountered.
🎯 Impact: Application crash (AttributeError/TypeError) when processing malicious or malformed blocklists.
🔧 Fix: Added strict type checking in `validate_folder_data` for `rules` and `rule_groups`.
✅ Verification: Added `test_validate_folder_data_structure` in `test_main.py` covering invalid inputs. Run `python3 -m pytest test_main.py` to verify.

---
*PR created automatically by Jules for task [13083465383994297818](https://jules.google.com/task/13083465383994297818) started by @abhimehro*