### PR TITLE
security: Fix TOCTOU vulnerability in cache file creation

### DIFF
--- a/main.py
+++ b/main.py
@@ -803,12 +803,12 @@ def save_disk_cache() -> None:
         # Write atomically: write to temp file, then rename
         # This prevents corrupted cache if process is killed mid-write
         temp_file = cache_file.with_suffix(".tmp")
-        with open(temp_file, "w", encoding="utf-8") as f:
-            json.dump(_disk_cache, f, indent=2)
         
-        # Set file permissions to user-only (rw-------)
-        if platform.system() != "Windows":
-            temp_file.chmod(0o600)
+        # Security: Use os.open to ensure file is created with 0o600 permissions
+        # This prevents TOCTOU race condition where file could be world-readable before chmod
+        fd = os.open(temp_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(_disk_cache, f, indent=2)
         
         # Atomic rename (POSIX guarantees atomicity)
         temp_file.replace(cache_file)


### PR DESCRIPTION
### 🛡️ Sentinel Security Fix

**Vulnerability:** Time-of-Check Time-of-Use (TOCTOU) / Race Condition in File Creation
**Severity:** LOW/MEDIUM (Local Information Disclosure)
**Impact:** On multi-user systems, a malicious actor could theoretically read the contents of the blocklist cache file in the brief window between file creation (with default umask permissions, typically 644) and the subsequent `chmod(0o600)` call.

**Fix:**
Replaced the insecure pattern:
```python
with open(path, "w") as f: ...
os.chmod(path, 0o600)
```

With the secure atomic pattern:
```python
fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
with os.fdopen(fd, "w") as f: ...
```

This ensures the file is *created* with 600 permissions, eliminating the race condition window.

**Verification:**
- `pytest tests/test_disk_cache.py` passed.
- Full test suite passed (138 tests).

---
*PR created automatically by Jules for task [2882225381289155477](https://jules.google.com/task/2882225381289155477) started by @abhimehro*