### PR TITLE
🎨 Palette: UX Improvement - Explicit [Block (Default)] Fallback

### DIFF
--- a/main.py
+++ b/main.py
@@ -343,6 +343,12 @@ def print_plan_details(plan_entry: Dict[str, Any]) -> None:
                 action_color = Colors.GREEN
                 action_text = f"({action_color}✅ {action_label}{Colors.ENDC})" if USE_COLORS else f"[{action_label}]"
 
+        # If action is still completely missing/unknown, default to Block (Default) for clearer UX
+        if not action_text:
+            action_label = "Block (Default)"
+            action_color = Colors.FAIL
+            action_text = f"({action_color}⛔ {action_label}{Colors.ENDC})" if USE_COLORS else f"[{action_label}]"
+
         if USE_COLORS:
             print(
                 f"  • {Colors.BOLD}{name:<{max_name_len}}{Colors.ENDC} : {formatted_rules:>{max_rules_len}} rules {action_text}"


### PR DESCRIPTION
Modified `print_plan_details` in `main.py` to handle cases where an action is completely missing/unknown. Instead of printing a blank space next to the rules count, it now defaults to `[Block (Default)]`. This ensures users always see a clear indication of what action is planned, matching the fallback expected behavior and avoiding visual anomalies in the output table.

Fixed broken test `test_parallel_fetch.py` by mocking the `validate_profile_id` to `True`.

---
*PR created automatically by Jules for task [10701116334433042967](https://jules.google.com/task/10701116334433042967) started by @abhimehro*