### PR TITLE
🎨 Palette: Prevent horizontal jitter in CLI animations

### DIFF
--- a/main.py
+++ b/main.py
@@ -508,13 +508,14 @@ def countdown_timer(seconds: int, message: str = "Waiting") -> None:
         return
 
     width = _get_progress_bar_width()
+    max_len = len(str(seconds))
 
     for remaining in range(seconds, 0, -1):
         progress = (seconds - remaining + 1) / seconds
         filled = int(width * progress)
         bar = "█" * filled + "·" * (width - filled)
         sys.stderr.write(
-            f"\r\033[K{Colors.CYAN}⏳ {message}: [{bar}] {remaining}s...{Colors.ENDC}"
+            f"\r\033[K{Colors.CYAN}⏳ {message}: [{bar}] {remaining:>{max_len}}s...{Colors.ENDC}"
         )
         sys.stderr.flush()
         time.sleep(1)
@@ -537,9 +538,11 @@ def render_progress_bar(
     bar = "█" * filled + "·" * (width - filled)
     percent = int(progress * 100)
 
+    total_str = str(total)
+
     # Use \033[K to clear line residue
     sys.stderr.write(
-        f"\r\033[K{Colors.CYAN}{prefix} {label}: [{bar}] {percent}% ({current}/{total}){Colors.ENDC}"
+        f"\r\033[K{Colors.CYAN}{prefix} {label}: [{bar}] {percent:>3}% ({current:>{len(total_str)}}/{total_str}){Colors.ENDC}"
     )
     sys.stderr.flush()
 


### PR DESCRIPTION
🎨 **Palette: Prevent horizontal jitter in CLI animations**

**💡 What:** 
Added dynamic width padding to the numbers printed in the `countdown_timer` and `render_progress_bar` functions within `main.py`.

**🎯 Why:**
When using `\r` (carriage return) for CLI animations, numbers that change length (like a percentage going from 9% to 10%, or a countdown going from 10s to 9s) cause the trailing text to shift back and forth horizontally. This "jitter" is visually distracting. By calculating the maximum width needed (e.g. padding to the length of the `total` items or the initial `seconds`), the text remains statically positioned.

**♿ Accessibility:**
A smoother, jitter-free visual experience reduces cognitive load and eye strain for terminal users.

**✅ Testing:**
Ran `uv run pytest tests/` and `uv run ruff check .` to ensure the core logic and visual tests still pass correctly.

---
*PR created automatically by Jules for task [17415194953348849669](https://jules.google.com/task/17415194953348849669) started by @abhimehro*