### PR TITLE
🎨 Palette: Add empty state hint with call-to-action

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2025-03-05 - [CLI Progress Line Residue]
 **Learning:** When using carriage return (`\r`) to animate CLI progress bars or countdowns, shrinking strings (e.g., transitioning from "10s" to "9s") leave visible ghost characters (residue) at the end of the line if not explicitly cleared.
 **Action:** Always prefix carriage-return updates with the ANSI clear-line sequence (`\033[K`) to ensure the entire line is cleanly re-rendered.
+
+## 2025-03-05 - [CLI Empty States]
+**Learning:** Presenting a simple "Nothing to do" message when an operation is empty leaves the user without guidance.
+**Action:** When presenting empty states in the CLI (e.g., no items to process), always provide actionable hints or call-to-actions, such as suggesting relevant CLI flags or configuration edits.

--- a/main.py
+++ b/main.py
@@ -380,8 +380,10 @@ def print_plan_details(plan_entry: dict[str, Any]) -> None:
     if not folders:
         if USE_COLORS:
             print(f"  {Colors.WARNING}No folders to sync.{Colors.ENDC}")
+            print(f"  {Colors.CYAN}💡 Hint: Add folder URLs using --folder-url or in your config.yaml{Colors.ENDC}")
         else:
             print("  No folders to sync.")
+            print("  Hint: Add folder URLs using --folder-url or in your config.yaml")
         return
 
     # Calculate max width for alignment

--- a/tests/test_plan_details.py
+++ b/tests/test_plan_details.py
@@ -55,6 +55,7 @@ def test_print_plan_details_empty_folders(capsys):
 
     assert "Plan Details for test_profile:" in output
     assert "No folders to sync." in output
+    assert "Hint: Add folder URLs using --folder-url or in your config.yaml" in output
 
 
 def test_print_plan_details_with_colors(capsys):


### PR DESCRIPTION
🎨 **Palette's Daily UX Update**

💡 **What:** Added an actionable hint to the empty state output when `print_plan_details` detects no folders to sync.
🎯 **Why:** Previously, the CLI just printed "No folders to sync." By providing a call-to-action (`Hint: Add folder URLs using --folder-url or in your config.yaml`), users aren't left stranded and know immediately how to fix the issue.
♿ **Accessibility/Usability:** Improves general usability and user guidance without adding clutter.

===== ELIR =====
PURPOSE: Added an actionable hint to the empty state in the CLI output to guide users on how to configure folders.
SECURITY: No security implications; just adding safe print statements.
FAILS IF: The terminal does not support print accurately (unlikely); gracefully falls back to non-ANSI string.
VERIFY: Run `python main.py --dry-run` with no config or `--folder-url` arguments and ensure the hint is displayed.
MAINTAIN: If new configuration methods are added, update this hint.

---
*PR created automatically by Jules for task [8248785477986519672](https://jules.google.com/task/8248785477986519672) started by @abhimehro*