### PR TITLE
🧹 Refactor push_rules to reduce parameter count using dataclasses

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -173,7 +173,9 @@ def test_push_rules_benchmark_10k():
     mock_client = DummyClient()
 
     start = time.perf_counter()
-    push_rules(profile_id, folder_name, folder_id, 1, 1, hostnames, set(), mock_client)
+    ctx = SyncContext(profile_id, mock_client, set())
+    action = RuleAction(1, 1)
+    push_rules(ctx, folder_name, folder_id, action, hostnames)
     elapsed = time.perf_counter() - start
     # Fail if significantly slower than baseline (update threshold after establishing baseline)
     assert elapsed < 30.0, f"10k rules took {elapsed:.2f}s (expected <30s)"

--- a/WARP.md
+++ b/WARP.md
@@ -95,13 +95,13 @@ The entire tool lives in `main.py` and is structured into clear phases:
    - `list_existing_folders()` – Helper that returns a `{folder_name -> folder_id}` mapping (used as fallback).
    - `get_all_existing_rules()` – Collects all existing rule PKs from both the root and each folder, using a `ThreadPoolExecutor` to parallelize per-folder fetches while accumulating into a shared `set` guarded by a lock.
    - `delete_folder()` – Deletes a folder by ID with error-logged failures.
-   - `create_folder()` – Creates a folder and tries to read its ID directly from the response; if that fails, it polls `GET /groups` with increasing waits (using `FOLDER_CREATION_DELAY`) until the new folder appears.
-   - `push_rules()` – Sends hostname rules in batches (`BATCH_SIZE`) to `POST /rules`, de-duplicating against the global `existing_rules` set and updating it as batches succeed.
+   - `create_folder()` – Creates a folder and tries to read its ID directly from the response; if that fails, it polls `GET /groups` with increasing waits (using `FOLDER_CREATION_DELAY`) until the new folder appears. Uses `SyncContext` and `RuleAction` objects.
+   - `push_rules()` – Sends hostname rules in batches (`BATCH_SIZE`) to `POST /rules`, de-duplicating against the global `ctx.existing_rules` set and updating it as batches succeed. Uses `SyncContext` and `RuleAction` objects.
 
 5. **Folder data processing**
    - `fetch_folder_data()` – Fetches and validates a single folder JSON document.
    - `warm_up_cache()` – Pre-fetches and caches folder JSON definitions in parallel, so subsequent parsing is cheap.
-   - `_process_single_folder()` – Given one parsed folder JSON, it:
+   - `_process_single_folder()` – Given one parsed folder JSON and a `SyncContext`, it:
      - Determines the main folder attributes (name, default action/status).
      - Creates the folder via `create_folder()`.
      - Handles either legacy single-action JSON (flat `rules`) or the newer multi-action `rule_groups` format, dispatching batched `push_rules()` calls for each group.

--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import argparse
 import concurrent.futures
 import contextlib
+from dataclasses import dataclass
 import getpass
 import ipaddress
 import json
@@ -64,6 +65,24 @@ from api_client import (
     _api_post,
     _api_post_form,
 )
+
+@dataclass(frozen=True)
+class RuleAction:
+    """Represents a rule action (do and status)."""
+
+    do: int
+    status: int
+
+
+@dataclass
+class SyncContext:
+    """Context for syncing rules and folders."""
+
+    profile_id: str
+    client: httpx.Client
+    existing_rules: set[str]
+    batch_executor: concurrent.futures.Executor | None = None
+
 
 # --------------------------------------------------------------------------- #
 # 0. Bootstrap – load secrets and configure logging
@@ -1773,9 +1792,7 @@ def delete_folder(
         return False
 
 
-def create_folder(
-    client: httpx.Client, profile_id: str, name: str, do: int, status: int
-) -> str | None:
+def create_folder(ctx: SyncContext, name: str, action: RuleAction) -> str | None:
     """
     Create a new folder and return its ID.
     Attempts to read ID from response first, then falls back to polling.
@@ -1783,9 +1800,9 @@ def create_folder(
     try:
         # 1. Send the Create Request
         response = _api_post(
-            client,
-            f"{API_BASE}/{profile_id}/groups",
-            data={"name": name, "do": do, "status": status},
+            ctx.client,
+            f"{API_BASE}/{ctx.profile_id}/groups",
+            data={"name": name, "do": action.do, "status": action.status},
         )
 
         # OPTIMIZATION: Try to grab ID directly from response to avoid the wait loop
@@ -1831,7 +1848,7 @@ def create_folder(
         # 2. Fallback: Poll for the new folder (The Robust Retry Logic)
         for attempt in range(MAX_RETRIES + 1):
             try:
-                data = _api_get(client, f"{API_BASE}/{profile_id}/groups").json()
+                data = _api_get(ctx.client, f"{API_BASE}/{ctx.profile_id}/groups").json()
                 groups = data.get("body", {}).get("groups", [])
 
                 for grp in groups:
@@ -1873,21 +1890,17 @@ def create_folder(
 
 
 def push_rules(
-    profile_id: str,
+    ctx: SyncContext,
     folder_name: str,
     folder_id: str,
-    do: int,
-    status: int,
+    action: RuleAction,
     hostnames: list[str],
-    existing_rules: set[str],
-    client: httpx.Client,
-    batch_executor: concurrent.futures.Executor | None = None,
 ) -> bool:
     """
     Pushes rules to a folder in batches, filtering duplicates and invalid rules.
 
     Deduplicates input, validates rules against RULE_PATTERN, and sends batches
-    in parallel for optimal performance. Updates existing_rules set with newly
+    in parallel for optimal performance. Updates ctx.existing_rules set with newly
     added rules. Returns True if all batches succeed.
     """
     if not hostnames:
@@ -1906,10 +1919,10 @@ def push_rules(
     # bypassing the Python loop overhead for the vast majority of items that are already synced.
     # FAST-PATH: If existing_rules is empty (e.g., first sync), avoid the list allocation.
     new_hostnames: typing.Iterable[str]
-    if not existing_rules:
+    if not ctx.existing_rules:
         new_hostnames = unique_hostnames_dict
     else:
-        new_hostnames = [h for h in unique_hostnames_dict if h not in existing_rules]
+        new_hostnames = [h for h in unique_hostnames_dict if h not in ctx.existing_rules]
 
     filtered_hostnames: list[str] = []
     skipped_unsafe = 0
@@ -1957,8 +1970,8 @@ def push_rules(
     total_batches = len(batches)
 
     # Optimization: Hoist loop invariants to avoid redundant computations
-    str_do = str(do)
-    str_status = str(status)
+    str_do = str(action.do)
+    str_status = str(action.status)
     str_group = str(folder_id)
     sanitized_folder_name = sanitize_for_log(folder_name)
     progress_label = f"Folder {sanitized_folder_name}"
@@ -1975,7 +1988,7 @@ def push_rules(
         data.update(zip(BATCH_KEYS, batch_data, strict=False))
 
         try:
-            _api_post_form(client, f"{API_BASE}/{profile_id}/rules", data=data)
+            _api_post_form(ctx.client, f"{API_BASE}/{ctx.profile_id}/rules", data=data)
             if not USE_COLORS:
                 log.info(
                     "Folder %s – batch %d: added %d rules",
@@ -2011,7 +2024,7 @@ def push_rules(
         result = process_batch(1, batches[0])
         if result:
             successful_batches += 1
-            existing_rules.update(result)
+            ctx.existing_rules.update(result)
 
         render_progress_bar(
             successful_batches,
@@ -2020,8 +2033,8 @@ def push_rules(
         )
     else:
         # Use provided executor or create a local one (fallback)
-        if batch_executor:
-            executor_ctx: contextlib.AbstractContextManager[concurrent.futures.Executor] = contextlib.nullcontext(batch_executor)
+        if ctx.batch_executor:
+            executor_ctx: contextlib.AbstractContextManager[concurrent.futures.Executor] = contextlib.nullcontext(ctx.batch_executor)
         else:
             executor_ctx = concurrent.futures.ThreadPoolExecutor(max_workers=3)
 
@@ -2035,7 +2048,7 @@ def push_rules(
                 result = future.result()
                 if result:
                     successful_batches += 1
-                    existing_rules.update(result)
+                    ctx.existing_rules.update(result)
 
                 render_progress_bar(
                     successful_batches,
@@ -2067,11 +2080,8 @@ def push_rules(
 
 
 def _process_single_folder(
+    ctx: SyncContext,
     folder_data: dict[str, Any],
-    profile_id: str,
-    existing_rules: set[str],
-    client: httpx.Client,
-    batch_executor: concurrent.futures.Executor | None = None,
 ) -> bool:
     grp = folder_data["group"]
     name = grp["group"].strip()
@@ -2079,42 +2089,37 @@ def _process_single_folder(
     # Client is now passed in, reusing the connection
     main_do = grp.get("action", {}).get("do", 0)
     main_status = grp.get("action", {}).get("status", 1)
+    main_action = RuleAction(do=main_do, status=main_status)
 
-    folder_id = create_folder(client, profile_id, name, main_do, main_status)
+    folder_id = create_folder(ctx, name, main_action)
     if not folder_id:
         return False
 
     folder_success = True
     if "rule_groups" in folder_data:
         for rule_group in folder_data["rule_groups"]:
-            action = rule_group.get("action", {})
-            do = action.get("do", 0)
-            status = action.get("status", 1)
+            action_data = rule_group.get("action", {})
+            action = RuleAction(
+                do=action_data.get("do", 0),
+                status=action_data.get("status", 1),
+            )
             hostnames = [r["PK"] for r in rule_group.get("rules", []) if r.get("PK")]
             if not push_rules(
-                profile_id,
+                ctx,
                 name,
                 folder_id,
-                do,
-                status,
+                action,
                 hostnames,
-                existing_rules,
-                client,
-                batch_executor=batch_executor,
             ):
                 folder_success = False
     else:
         hostnames = [r["PK"] for r in folder_data.get("rules", []) if r.get("PK")]
         if not push_rules(
-            profile_id,
+            ctx,
             name,
             folder_id,
-            main_do,
-            main_status,
+            main_action,
             hostnames,
-            existing_rules,
-            client,
-            batch_executor=batch_executor,
         ):
             folder_success = False
 
@@ -2313,17 +2318,21 @@ def sync_profile(
                 )
                 existing_rules = set()
 
+            ctx = SyncContext(
+                profile_id=profile_id,
+                client=client,
+                existing_rules=existing_rules,
+                batch_executor=shared_executor,
+            )
+
             with concurrent.futures.ThreadPoolExecutor(
                 max_workers=max_workers
             ) as executor:
                 future_to_folder = {
                     executor.submit(
                         _process_single_folder,
+                        ctx,
                         folder_data,
-                        profile_id,
-                        existing_rules,
-                        client,  # Pass the persistent client
-                        batch_executor=shared_executor,
                     ): folder_data
                     for folder_data in folder_data_list
                 }

--- a/test_main.py
+++ b/test_main.py
@@ -87,15 +87,14 @@ def test_push_rules_updates_data_with_batch_keys(monkeypatch):
     batch_size = m.BATCH_SIZE
     hostnames = [f"host{i}" for i in range(batch_size)]
 
+    ctx = m.SyncContext(profile_id="p1", client=mock_client, existing_rules=set())
+    action = m.RuleAction(do=1, status=1)
     m.push_rules(
-        profile_id="p1",
+        ctx=ctx,
         folder_name="f1",
         folder_id="fid1",
-        do=1,
-        status=1,
+        action=action,
         hostnames=hostnames,
-        existing_rules=set(),
-        client=mock_client,
     )
 
     assert mock_post_form.called
@@ -120,15 +119,14 @@ def test_push_rules_updates_existing_rules(monkeypatch):
     hostnames = ["h1", "h2"]
     existing_rules = set()
 
+    ctx = m.SyncContext(profile_id="p1", client=mock_client, existing_rules=existing_rules)
+    action = m.RuleAction(do=1, status=1)
     m.push_rules(
-        profile_id="p1",
+        ctx=ctx,
         folder_name="f1",
         folder_id="fid1",
-        do=1,
-        status=1,
+        action=action,
         hostnames=hostnames,
-        existing_rules=existing_rules,
-        client=mock_client,
     )
 
     assert "h1" in existing_rules
@@ -144,7 +142,9 @@ def test_push_rules_logs_conditionally_use_colors(monkeypatch):
     monkeypatch.setattr(m_no_color, "log", mock_log)
 
     hostnames = ["h1"]
-    m_no_color.push_rules("p", "f", "fid", 1, 1, hostnames, set(), MagicMock())
+    ctx = m_no_color.SyncContext(profile_id="p", client=MagicMock(), existing_rules=set())
+    action = m_no_color.RuleAction(do=1, status=1)
+    m_no_color.push_rules(ctx, "f", "fid", action, hostnames)
 
     # Should log info when USE_COLORS is False (lines 567-571)
     # log.info("Folder %s – batch %d: added %d rules", ...)
@@ -164,7 +164,9 @@ def test_push_rules_logs_conditionally_use_colors(monkeypatch):
     monkeypatch.setattr(m_color, "log", mock_log)
     mock_log.reset_mock()
 
-    m_color.push_rules("p", "f", "fid", 1, 1, hostnames, set(), MagicMock())
+    ctx = m_color.SyncContext(profile_id="p", client=MagicMock(), existing_rules=set())
+    action = m_color.RuleAction(do=1, status=1)
+    m_color.push_rules(ctx, "f", "fid", action, hostnames)
 
     # Should NOT log info for batch success when USE_COLORS is True
     # It might log other things, but not the batch success message handled by stderr
@@ -184,7 +186,9 @@ def test_push_rules_writes_colored_stderr(monkeypatch):
     monkeypatch.setattr(sys, "stderr", mock_stderr)
 
     hostnames = ["h1"]
-    m.push_rules("p", "f", "fid", 1, 1, hostnames, set(), MagicMock())
+    ctx = m.SyncContext(profile_id="p", client=MagicMock(), existing_rules=set())
+    action = m.RuleAction(do=1, status=1)
+    m.push_rules(ctx, "f", "fid", action, hostnames)
 
     # Check for color codes in stderr writes
     # Look for CYAN (progress) and GREEN (completion)

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -82,5 +82,7 @@ def test_push_rules_benchmark_10k(benchmark, overlap_ratio):
             return Response()
 
     mock_client = DummyClient()
+    ctx = main.SyncContext(profile_id=profile_id, client=mock_client, existing_rules=existing_rules)
+    action = main.RuleAction(do=1, status=1)
 
-    benchmark(main.push_rules, profile_id, folder_name, folder_id, 1, 1, hostnames, existing_rules, mock_client)
+    benchmark(main.push_rules, ctx, folder_name, folder_id, action, hostnames)

--- a/tests/test_exception_logging.py
+++ b/tests/test_exception_logging.py
@@ -156,7 +156,9 @@ class TestExceptionLogging(unittest.TestCase):
         # Mock time.sleep to avoid actual delays
         with patch("main.time.sleep"):
             # Action - this will try to call json(), catch exception, and log
-            result = main.create_folder(client, profile_id, folder_name, 1, 1)
+            ctx = main.SyncContext(profile_id=profile_id, client=client, existing_rules=set())
+            action = main.RuleAction(do=1, status=1)
+            result = main.create_folder(ctx, folder_name, action)
 
         # Should return None after retries fail
         self.assertIsNone(result)

--- a/tests/test_log_sanitization.py
+++ b/tests/test_log_sanitization.py
@@ -42,8 +42,9 @@ class TestLogSanitization(unittest.TestCase):
         unsafe_name = "\x1b[31mUNSAFE"
 
         # Call
-        client = MagicMock()
-        main.create_folder(client, "pid", unsafe_name, 0, 1)
+        ctx = main.SyncContext(profile_id="pid", client=MagicMock(), existing_rules=set())
+        action = main.RuleAction(do=0, status=1)
+        main.create_folder(ctx, unsafe_name, action)
 
         # Check logs: ensure we do not log the raw unsafe name, but do log the sanitized name.
         # For this test file, I want it to PASS when the code is FIXED.

--- a/tests/test_push_rules_perf.py
+++ b/tests/test_push_rules_perf.py
@@ -49,15 +49,18 @@ class TestPushRulesPerf(unittest.TestCase):
         # self.main is likely sys.modules['main'] due to setUp logic
 
         with patch("main._api_post_form") as mock_post:
+            ctx = self.main.SyncContext(
+                profile_id=self.profile_id,
+                client=self.client,
+                existing_rules=self.existing_rules,
+            )
+            action = self.main.RuleAction(do=self.do, status=self.status)
             self.main.push_rules(
-                self.profile_id,
+                ctx,
                 self.folder_name,
                 self.folder_id,
-                self.do,
-                self.status,
+                action,
                 hostnames,
-                self.existing_rules,
-                self.client,
             )
 
             self.assertTrue(mock_post.called, "Expected _api_post_form to be called")
@@ -89,15 +92,18 @@ class TestPushRulesPerf(unittest.TestCase):
         mock_as_completed.return_value = [mock_future, mock_future]  # 2 batches
 
         with patch("main._api_post_form"):
+            ctx = self.main.SyncContext(
+                profile_id=self.profile_id,
+                client=self.client,
+                existing_rules=self.existing_rules,
+            )
+            action = self.main.RuleAction(do=self.do, status=self.status)
             self.main.push_rules(
-                self.profile_id,
+                ctx,
                 self.folder_name,
                 self.folder_id,
-                self.do,
-                self.status,
+                action,
                 hostnames,
-                self.existing_rules,
-                self.client,
             )
 
         # This should ALWAYS be True
@@ -120,15 +126,18 @@ class TestPushRulesPerf(unittest.TestCase):
             existing_rules = {"h1"}
 
             with patch("main._api_post_form"):
+                ctx = self.main.SyncContext(
+                    profile_id=self.profile_id,
+                    client=self.client,
+                    existing_rules=existing_rules,
+                )
+                action = self.main.RuleAction(do=self.do, status=self.status)
                 self.main.push_rules(
-                    self.profile_id,
+                    ctx,
                     self.folder_name,
                     self.folder_id,
-                    self.do,
-                    self.status,
+                    action,
                     hostnames,
-                    existing_rules,
-                    self.client,
                 )
 
             # h1 is in existing_rules, so we should skip validation for it.
@@ -153,16 +162,20 @@ class TestPushRulesPerf(unittest.TestCase):
         # Mock as_completed to return our futures
         mock_as_completed.return_value = [mock_future, mock_future]
 
+        ctx = self.main.SyncContext(
+            profile_id=self.profile_id,
+            client=self.client,
+            existing_rules=self.existing_rules,
+            batch_executor=mock_executor,
+        )
+        action = self.main.RuleAction(do=self.do, status=self.status)
+
         self.main.push_rules(
-            self.profile_id,
+            ctx,
             self.folder_name,
             self.folder_id,
-            self.do,
-            self.status,
+            action,
             hostnames,
-            self.existing_rules,
-            self.client,
-            batch_executor=mock_executor,
         )
 
         # Verify executor.submit was called twice (once for each batch)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -38,15 +38,14 @@ def test_push_rules_filters_xss_payloads():
             "*.wildcard.com",
         ]
 
+        ctx = main.SyncContext(profile_id="p1", client=mock_client, existing_rules=set())
+        action = main.RuleAction(do=1, status=1)
         main.push_rules(
-            profile_id="p1",
+            ctx=ctx,
             folder_name="f1",
             folder_id="fid1",
-            do=1,
-            status=1,
+            action=action,
             hostnames=malicious_rules,
-            existing_rules=set(),
-            client=mock_client,
         )
 
         # Check what was sent

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -61,15 +61,14 @@ def test_push_rules_sanitizes_token_in_debug_logs(caplog):
 
     # Patch time.sleep to avoid waiting
     with patch("time.sleep"):
+        ctx = main.SyncContext(profile_id="p1", client=mock_client, existing_rules=set())
+        action = main.RuleAction(do=0, status=1)
         res = main.push_rules(
-            profile_id="p1",
+            ctx=ctx,
             folder_name="f1",
             folder_id="fid1",
-            do=0,
-            status=1,
+            action=action,
             hostnames=["rule1"],
-            existing_rules=set(),
-            client=mock_client,
         )
 
         # push_rules catches the error and returns False (or continues if batch failed)

--- a/tests/test_status_hints.py
+++ b/tests/test_status_hints.py
@@ -145,10 +145,13 @@ class TestPushRulesBatchHints:
         with patch.object(main, "_api_post_form", side_effect=err):
             with patch.object(main, "log", mock_log):
                 with patch.object(main, "USE_COLORS", False):
-                    main.push_rules(
-                        "profile", "folder", "fid", 1, 1,
-                        ["example.com"], set(), mock_client
+                    ctx = main.SyncContext(
+                        profile_id="profile",
+                        client=mock_client,
+                        existing_rules=set(),
                     )
+                    action = main.RuleAction(do=1, status=1)
+                    main.push_rules(ctx, "folder", "fid", action, ["example.com"])
 
         error_calls = str(mock_log.error.call_args_list)
         assert "TOKEN" in error_calls
@@ -161,10 +164,13 @@ class TestPushRulesBatchHints:
         with patch.object(main, "_api_post_form", side_effect=err):
             with patch.object(main, "log", mock_log):
                 with patch.object(main, "USE_COLORS", False):
-                    main.push_rules(
-                        "profile", "folder", "fid", 1, 1,
-                        ["example.com"], set(), mock_client
+                    ctx = main.SyncContext(
+                        profile_id="profile",
+                        client=mock_client,
+                        existing_rules=set(),
                     )
+                    action = main.RuleAction(do=1, status=1)
+                    main.push_rules(ctx, "folder", "fid", action, ["example.com"])
 
         error_calls = str(mock_log.error.call_args_list)
         assert "rate" in error_calls.lower()
@@ -177,10 +183,13 @@ class TestPushRulesBatchHints:
         with patch.object(main, "_api_post_form", side_effect=err):
             with patch.object(main, "log", mock_log):
                 with patch.object(main, "USE_COLORS", False):
-                    main.push_rules(
-                        "profile", "folder", "fid", 1, 1,
-                        ["example.com"], set(), mock_client
+                    ctx = main.SyncContext(
+                        profile_id="profile",
+                        client=mock_client,
+                        existing_rules=set(),
                     )
+                    action = main.RuleAction(do=1, status=1)
+                    main.push_rules(ctx, "folder", "fid", action, ["example.com"])
 
         error_calls = str(mock_log.error.call_args_list)
         assert "HTTP 503" in error_calls


### PR DESCRIPTION
This PR addresses the code health issue where `push_rules` had too many parameters. I introduced two logical data structures:

1. `SyncContext`: Groups execution-level state (profile ID, HTTP client, shared executor, and the set of existing rules).
2. `RuleAction`: Groups rule-specific settings (do and status).

The refactoring was applied consistently across the main sync call chain (`create_folder`, `push_rules`, and `_process_single_folder`), significantly improving the maintainability of the core logic.

Verification:
- Performed a full syntax check on `main.py` and the entire `tests/` directory using `python3 -m py_compile`.
- Updated all identified call sites in both production code and the test suite.
- Updated project documentation (`PERFORMANCE.md`, `WARP.md`) to reflect the new architectural pattern.


---
*PR created automatically by Jules for task [6546569947113645392](https://jules.google.com/task/6546569947113645392) started by @abhimehro*