### PR TITLE
🎨 Palette: Use DIM formatting for secondary CLI hints to reduce visual noise

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -17,3 +17,7 @@
 ## 2025-03-05 - [CLI Empty States]
 **Learning:** Presenting a simple "Nothing to do" message when an operation is empty leaves the user without guidance.
 **Action:** When presenting empty states in the CLI (e.g., no items to process), always provide actionable hints or call-to-actions, such as suggesting relevant CLI flags or configuration edits.
+
+## 2025-03-12 - [Visual Hierarchy in CLI]
+**Learning:** Using bright colors (like CYAN) for both primary actions and secondary hints creates visual noise and makes it harder for users to focus on what matters.
+**Action:** Use DIM ANSI escape codes (\033[2m) for secondary or optional CLI text (like hints and follow-up instructions) to establish a clear visual hierarchy and reduce noise.

--- a/main.py
+++ b/main.py
@@ -191,6 +191,7 @@ class Colors:
         ENDC = "\033[0m"
         BOLD = "\033[1m"
         UNDERLINE = "\033[4m"
+        DIM = "\033[2m"
     else:
         HEADER = ""
         BLUE = ""
@@ -201,6 +202,7 @@ class Colors:
         ENDC = ""
         BOLD = ""
         UNDERLINE = ""
+        DIM = ""
 
 
 class Box:
@@ -458,7 +460,7 @@ log = logging.getLogger("control-d-sync")
 API_BASE = "https://api.controld.com/profiles"
 USER_AGENT = "Control-D-Sync/0.1.0"
 
-EMPTY_INPUT_HINT = f"   {Colors.CYAN}💡 Hint: Please type a value and press Enter, or press Ctrl+C/Ctrl+D to cancel.{Colors.ENDC}"
+EMPTY_INPUT_HINT = f"   {Colors.DIM}💡 Hint: Please type a value and press Enter, or press Ctrl+C/Ctrl+D to cancel.{Colors.ENDC}"
 
 # Pre-compiled regex patterns for hot-path validation (>2x speedup on 10k+ items)
 PROFILE_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
@@ -569,7 +571,7 @@ def print_plan_details(plan_entry: PlanEntry) -> None:
     if not folders:
         if USE_COLORS:
             print(f"  {Colors.WARNING}No folders to sync.{Colors.ENDC}")
-            print(f"  {Colors.CYAN}💡 Hint: Add folder URLs using --folder-url or in your config.yaml{Colors.ENDC}")
+            print(f"  {Colors.DIM}💡 Hint: Add folder URLs using --folder-url or in your config.yaml{Colors.ENDC}")
         else:
             print("  No folders to sync.")
             print("  Hint: Add folder URLs using --folder-url or in your config.yaml")
@@ -2777,7 +2779,7 @@ def main() -> None:
                 exit(1)
         else:
             print(f"{Colors.CYAN}ℹ No cache file found, nothing to clear{Colors.ENDC}")
-            print(f"{Colors.CYAN}💡 Hint: The cache file will be created or updated after a successful sync run without --dry-run{Colors.ENDC}")
+            print(f"{Colors.DIM}💡 Hint: The cache file will be created or updated after a successful sync run without --dry-run{Colors.ENDC}")
         _disk_cache.clear()
         exit(0)
     profiles_arg = (
@@ -2833,7 +2835,7 @@ def main() -> None:
         if not profile_ids:
             print(f"{Colors.CYAN}ℹ Profile ID is missing.{Colors.ENDC}")
             print(
-                f"{Colors.CYAN}  You can find this in the URL of your profile in the Control D Dashboard (or just paste the URL).{Colors.ENDC}"
+                f"{Colors.DIM}  You can find this in the URL of your profile in the Control D Dashboard (or just paste the URL).{Colors.ENDC}"
             )
 
             def validate_profile_input(value: str) -> bool:
@@ -2855,7 +2857,7 @@ def main() -> None:
         if not TOKEN:
             print(f"{Colors.CYAN}ℹ API Token is missing.{Colors.ENDC}")
             print(
-                f"{Colors.CYAN}  You can generate one at: https://controld.com/account/manage-account{Colors.ENDC}"
+                f"{Colors.DIM}  You can generate one at: https://controld.com/account/manage-account{Colors.ENDC}"
             )
 
             t_input = get_password(


### PR DESCRIPTION
🎨 **Palette: Establish Clearer Visual Hierarchy in CLI**

💡 **What:** Added the `DIM` ANSI escape code (`\033[2m`) to the `Colors` class and applied it to secondary text like CLI hints and follow-up instructions.
🎯 **Why:** To reduce visual noise. Previously, bright colors (like CYAN) were used for both primary info and secondary hints, making it harder for users to focus. DIM styling pushes secondary information to the background until the user needs it.
♿ **Accessibility:** Improves readability by establishing a clear visual hierarchy and reducing the cognitive load caused by excessive bright colors in the terminal.

(Changes are well under 50 lines and existing tests pass).

---
*PR created automatically by Jules for task [16210150631064368340](https://jules.google.com/task/16210150631064368340) started by @abhimehro*