### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF parser differential in URL validation

### DIFF
--- a/main.py
+++ b/main.py
@@ -1097,8 +1097,10 @@ def validate_folder_url(url: str) -> bool:
         return False
 
     try:
-        parsed = urlparse(url)
-        hostname = parsed.hostname
+        # Use httpx.URL to parse the hostname to prevent parser differentials
+        # between urllib.parse and the httpx client used to fetch the URL.
+        parsed = httpx.URL(url)
+        hostname = parsed.host
         if not hostname:
             return False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,3 +55,6 @@ ignore = [
     "SIM115",
     "SIM117",
 ]
+
+[dependency-groups]
+dev = []

--- a/uv.lock
+++ b/uv.lock
@@ -151,6 +151,9 @@ requires-dist = [
 ]
 provides-extras = ["dev"]
 
+[package.metadata.requires-dev]
+dev = []
+
 [[package]]
 name = "distlib"
 version = "0.4.0"


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** `validate_folder_url` was using `urllib.parse.urlparse` to extract the hostname for DNS resolution verification, but the actual request was performed using `httpx`. These two parsing engines handle malformed URLs (e.g., those with unencoded backslashes, percent-encoded spaces before the `@` sign, or misaligned ports) differently. This created a parser differential where `validate_hostname` could validate one host (e.g., `example.com`), while `httpx` would connect to a completely different host (e.g., `127.0.0.1`), leading to a Server-Side Request Forgery (SSRF) bypass.
🎯 **Impact:** An attacker could supply a specially crafted malicious URL that tricks the validation engine into verifying a safe IP, while the HTTP client connects to internal or restricted IP addresses like `127.0.0.1` or `169.254.169.254`.
🔧 **Fix:** Replaced the use of `urllib.parse.urlparse` with `httpx.URL` in `validate_folder_url`. This guarantees that the hostname verified by the security checks is the exact same hostname the `httpx` HTTP client uses to form the connection.
✅ **Verification:** Ran `pytest tests/test_ssrf.py` and `pytest tests/test_ssrf_enhanced.py`. They pass correctly and block malicious connections. Cleaned up all workspace fuzzing scripts to ensure code purity.

---
*PR created automatically by Jules for task [1476181947453521192](https://jules.google.com/task/1476181947453521192) started by @abhimehro*