### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix SSRF parser differentials

### DIFF
--- a/main.py
+++ b/main.py
@@ -36,7 +36,6 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any, NotRequired, TypedDict, TypeGuard, cast
 from collections.abc import Callable, Sequence
-from urllib.parse import urlparse
 
 import httpx
 import yaml
@@ -1097,8 +1096,8 @@ def validate_folder_url(url: str) -> bool:
         return False
 
     try:
-        parsed = urlparse(url)
-        hostname = parsed.hostname
+        parsed = httpx.URL(url)
+        hostname = parsed.host
         if not hostname:
             return False
 


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix SSRF parser differentials

🚨 **Severity:** MEDIUM
💡 **Vulnerability:** SSRF parser differentials / URL parsing confusion. The application used `urllib.parse.urlparse` to validate the `hostname` in the `validate_folder_url` function, but subsequently used the `httpx` library to fetch the data.
🎯 **Impact:** An attacker could craft a complex URL that `urllib.parse` resolves to a safe host (passing validation) but `httpx` interprets as a different, internal, or restricted host, leading to Server-Side Request Forgery (SSRF).
🔧 **Fix:** Replaced `urllib.parse.urlparse` with `httpx.URL` inside `validate_folder_url` so that the URL parsing matches the exact library used for HTTP requests.
✅ **Verification:** Verified by running `uv run pytest tests/ -v` and `uv run ruff check .` which both pass. Additionally, the application correctly works in dry-run mode.

---
*PR created automatically by Jules for task [14304196034768663761](https://jules.google.com/task/14304196034768663761) started by @abhimehro*