### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix DoS risk by adding URL length limit

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - DoS Risk from Unrestricted URL Lengths
+**Vulnerability:** The application was not enforcing a maximum length limit on parsed folder URLs before validation via `httpx.URL()` and downstream logic. This could allow an attacker to trigger a Denial of Service (DoS) attack by passing excessively long, maliciously crafted URLs designed to exhaust parsing resources.
+**Learning:** Even internal tooling is susceptible to resource exhaustion if user input length is not constrained before running relatively complex regexes or parsers.
+**Prevention:** Apply a strict max length check (e.g., `MAX_URL_LENGTH = 2048`) on URL strings as the very first operation inside the URL validation function.

--- a/main.py
+++ b/main.py
@@ -486,6 +486,7 @@ _DANGEROUS_FOLDER_CHARS.update(["/", "\\"])
 MAX_FOLDER_NAME_LENGTH = 64
 MAX_RULE_LENGTH = 255
 MAX_PROFILE_ID_LENGTH = 64
+MAX_URL_LENGTH = 2048
 # In constants section
 DEFAULT_HTTP_TIMEOUT = httpx.Timeout(10.0, connect=5.0)
 # Security: Unicode Bidi control characters (prevent RTLO/homograph attacks)
@@ -1099,6 +1100,12 @@ def validate_folder_url(url: str) -> bool:
     Validates a folder URL.
     Cached to avoid repeated URL parsing for the same URL.
     """
+    if len(url) > MAX_URL_LENGTH:
+        log.warning(
+            f"Skipping URL exceeding maximum length ({MAX_URL_LENGTH}): {sanitize_for_log(url[:100])}..."
+        )
+        return False
+
     if not url.startswith("https://"):
         log.warning(
             f"Skipping unsafe or invalid URL (must be https): {sanitize_for_log(url)}"


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The application was not enforcing a maximum length limit on parsed folder URLs before validation via `httpx.URL()` and downstream logic. This could allow an attacker to trigger a Denial of Service (DoS) attack by passing excessively long, maliciously crafted URLs designed to exhaust parsing resources.
🎯 Impact: An attacker could potentially cause resource exhaustion (CPU/Memory) by feeding extremely long strings as URLs, degrading performance or crashing the application.
🔧 Fix: Added a strict max length check (`MAX_URL_LENGTH = 2048`) on URL strings as the very first operation inside the URL validation function.
✅ Verification: Ensure the unit tests pass (`uv run pytest`) and no linter errors are introduced (`uv run ruff check`). Observe that URLs longer than 2048 characters are rejected immediately.

---
*PR created automatically by Jules for task [11364024879743200095](https://jules.google.com/task/11364024879743200095) started by @abhimehro*