### PR TITLE
🎨 Palette: Retain semantic emojis and success dashboard link in NO_COLOR mode

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -45,4 +45,4 @@
 
 ## 2026-04-04 - [NO_COLOR Delight Fallbacks]
 **Learning:** Completely suppressing output in NO_COLOR environments hides actionable hints and URLs, breaking the fundamental UX of CLI success/failure messages.
-**Action:** In NO_COLOR settings, print explicit uncolored message strings and avoid early returns that suppress semantic content like hints and URLs.
+**Action:** Rely on ANSI strip-safe empty string resolution in NO_COLOR settings to preserve semantic content, instead of outright condition-blocking UI blocks.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -45,4 +45,4 @@
 
 ## 2026-04-04 - [NO_COLOR Delight Fallbacks]
 **Learning:** Completely suppressing output in NO_COLOR environments hides actionable hints and URLs, breaking the fundamental UX of CLI success/failure messages.
-**Action:** Rely on ANSI strip-safe empty string resolution in NO_COLOR settings to preserve semantic content, instead of outright condition-blocking UI blocks.
+**Action:** In NO_COLOR settings, print explicit uncolored message strings and avoid early returns that suppress semantic content like hints and URLs.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -42,3 +42,7 @@
 
 **Learning:** While intercepting strings like "n" or "no" for cancellation in interactive boolean prompts (e.g., "Ready to launch?") is good UX, applying this same interception logic universally to *generic* input functions (like `get_validated_input` or `get_password`) introduces severe functional and security regressions. A user whose valid answer is "no" or whose password happens to match a cancellation string will be unexpectedly booted from the application.
 **Action:** Confine string-based cancellation interception to specific, appropriate contexts (like interactive confirmations). For generic input and password fields, rely solely on standard interrupt signals (Ctrl+C / Ctrl+D).
+
+## 2026-04-04 - [NO_COLOR Delight Fallbacks]
+**Learning:** Completely suppressing output in NO_COLOR environments hides actionable hints and URLs, breaking the fundamental UX of CLI success/failure messages.
+**Action:** Rely on ANSI strip-safe empty string resolution in NO_COLOR settings to preserve semantic content, instead of outright condition-blocking UI blocks.

--- a/main.py
+++ b/main.py
@@ -625,9 +625,7 @@ def print_plan_details(plan_entry: PlanEntry) -> None:
                 f"  {Colors.DIM}💡 Hint: Add folder URLs using --folder-url or in your config.yaml{Colors.ENDC}"
             )
         else:
-            # Keep the no-color message text stable because tests and plain-text
-            # consumers may rely on this exact output.
-            print("  No folders to sync.")
+            print("  ⚠️  No folders to sync.")
             print("  💡 Hint: Add folder URLs using --folder-url or in your config.yaml")
         return
 

--- a/main.py
+++ b/main.py
@@ -566,6 +566,48 @@ api_client._sanitize_fn = sanitize_for_log
 cache._sanitize_fn = sanitize_for_log
 
 
+def _get_action_text(folder: PlanFolderEntry) -> str:
+    """Determine the properly formatted action text/emoji for a folder."""
+    action_color = Colors.FAIL
+    action_label = "Block (Default)"
+    emoji = "⛔"
+
+    # Check for multiple rule groups first
+    if "rule_groups" in folder and folder["rule_groups"]:
+        actions = {rg.get("action") for rg in folder["rule_groups"]}
+        if len(actions) > 1:
+            action_label = "Mixed"
+            action_color = Colors.WARNING
+            emoji = "⚠️ "
+        else:
+            # All groups have same action
+            action_val = next(iter(actions))
+            if action_val == 1:
+                action_label = "Allow"
+                action_color = Colors.GREEN
+                emoji = "✅"
+            else:
+                action_label = "Block"
+                action_color = Colors.FAIL
+                emoji = "⛔"
+    # Fallback to single action if not set
+    elif "action" in folder:
+        action_val = folder["action"]
+        if action_val == 1:
+            action_label = "Allow"
+            action_color = Colors.GREEN
+            emoji = "✅"
+        else:
+            action_label = "Block"
+            action_color = Colors.FAIL
+            emoji = "⛔"
+
+    if USE_COLORS:
+        return f"({action_color}{emoji} {action_label}{Colors.ENDC})"
+
+    return f"[{emoji} {action_label}]"
+
+
 def print_plan_details(plan_entry: PlanEntry) -> None:
     """Pretty-print the folder-level breakdown during a dry-run."""
     profile = sanitize_for_log(plan_entry.get("profile", "unknown"))
@@ -600,71 +642,7 @@ def print_plan_details(plan_entry: PlanEntry) -> None:
         rules_count = folder.get("rules", 0)
         formatted_rules = f"{rules_count:,}"
 
-        # Determine action (Block/Allow)
-        action_text = ""
-        action_color = ""
-        action_label = ""
-
-        # Check for multiple rule groups first
-        if "rule_groups" in folder and folder["rule_groups"]:
-            actions = {rg.get("action") for rg in folder["rule_groups"]}
-            if len(actions) > 1:
-                action_label = "Mixed"
-                action_color = Colors.WARNING
-                action_text = (
-                    f"({action_color}⚠️  {action_label}{Colors.ENDC})"
-                    if USE_COLORS
-                    else f"[⚠️  {action_label}]"
-                )
-            else:
-                # All groups have same action
-                action_val = next(iter(actions))
-                if action_val == 0:
-                    action_label = "Block"
-                    action_color = Colors.FAIL
-                    action_text = (
-                        f"({action_color}⛔ {action_label}{Colors.ENDC})"
-                        if USE_COLORS
-                        else f"[⛔ {action_label}]"
-                    )
-                elif action_val == 1:
-                    action_label = "Allow"
-                    action_color = Colors.GREEN
-                    action_text = (
-                        f"({action_color}✅ {action_label}{Colors.ENDC})"
-                        if USE_COLORS
-                        else f"[✅ {action_label}]"
-                    )
-
-        # Fallback to single action if not set
-        if not action_text and "action" in folder:
-            action_val = folder["action"]
-            if action_val == 0:
-                action_label = "Block"
-                action_color = Colors.FAIL
-                action_text = (
-                    f"({action_color}⛔ {action_label}{Colors.ENDC})"
-                    if USE_COLORS
-                    else f"[⛔ {action_label}]"
-                )
-            elif action_val == 1:
-                action_label = "Allow"
-                action_color = Colors.GREEN
-                action_text = (
-                    f"({action_color}✅ {action_label}{Colors.ENDC})"
-                    if USE_COLORS
-                    else f"[✅ {action_label}]"
-                )
-
-        # If action is still completely missing/unknown, default to Block (Default) for clearer UX
-        if not action_text:
-            action_label = "Block (Default)"
-            action_color = Colors.FAIL
-            action_text = (
-                f"({action_color}⛔ {action_label}{Colors.ENDC})"
-                if USE_COLORS
-                else f"[⛔ {action_label}]"
-            )
+        action_text = _get_action_text(folder)
 
         bullet = "•" if USE_COLORS else "-"
         if USE_COLORS:

--- a/main.py
+++ b/main.py
@@ -625,7 +625,9 @@ def print_plan_details(plan_entry: PlanEntry) -> None:
                 f"  {Colors.DIM}💡 Hint: Add folder URLs using --folder-url or in your config.yaml{Colors.ENDC}"
             )
         else:
-            print("  ⚠️  No folders to sync.")
+            # Keep the no-color message text stable because tests and plain-text
+            # consumers may rely on this exact output.
+            print("  No folders to sync.")
             print("  💡 Hint: Add folder URLs using --folder-url or in your config.yaml")
         return
 

--- a/main.py
+++ b/main.py
@@ -574,16 +574,16 @@ def print_plan_details(plan_entry: PlanEntry) -> None:
     if USE_COLORS:
         print(f"\n{Colors.HEADER}📝 Plan Details for {profile}:{Colors.ENDC}")
     else:
-        print(f"\nPlan Details for {profile}:")
+        print(f"\n📝 Plan Details for {profile}:")
 
     if not folders:
         if USE_COLORS:
-            print(f"  {Colors.WARNING}No folders to sync.{Colors.ENDC}")
+            print(f"  {Colors.WARNING}⚠️  No folders to sync.{Colors.ENDC}")
             print(
                 f"  {Colors.DIM}💡 Hint: Add folder URLs using --folder-url or in your config.yaml{Colors.ENDC}"
             )
         else:
-            print("  No folders to sync.")
+            print("  ⚠️  No folders to sync.")
             print("  💡 Hint: Add folder URLs using --folder-url or in your config.yaml")
         return
 
@@ -614,7 +614,7 @@ def print_plan_details(plan_entry: PlanEntry) -> None:
                 action_text = (
                     f"({action_color}⚠️  {action_label}{Colors.ENDC})"
                     if USE_COLORS
-                    else f"[{action_label}]"
+                    else f"[⚠️  {action_label}]"
                 )
             else:
                 # All groups have same action
@@ -625,7 +625,7 @@ def print_plan_details(plan_entry: PlanEntry) -> None:
                     action_text = (
                         f"({action_color}⛔ {action_label}{Colors.ENDC})"
                         if USE_COLORS
-                        else f"[{action_label}]"
+                        else f"[⛔ {action_label}]"
                     )
                 elif action_val == 1:
                     action_label = "Allow"
@@ -633,7 +633,7 @@ def print_plan_details(plan_entry: PlanEntry) -> None:
                     action_text = (
                         f"({action_color}✅ {action_label}{Colors.ENDC})"
                         if USE_COLORS
-                        else f"[{action_label}]"
+                        else f"[✅ {action_label}]"
                     )
 
         # Fallback to single action if not set
@@ -645,7 +645,7 @@ def print_plan_details(plan_entry: PlanEntry) -> None:
                 action_text = (
                     f"({action_color}⛔ {action_label}{Colors.ENDC})"
                     if USE_COLORS
-                    else f"[{action_label}]"
+                    else f"[⛔ {action_label}]"
                 )
             elif action_val == 1:
                 action_label = "Allow"
@@ -653,7 +653,7 @@ def print_plan_details(plan_entry: PlanEntry) -> None:
                 action_text = (
                     f"({action_color}✅ {action_label}{Colors.ENDC})"
                     if USE_COLORS
-                    else f"[{action_label}]"
+                    else f"[✅ {action_label}]"
                 )
 
         # If action is still completely missing/unknown, default to Block (Default) for clearer UX
@@ -663,16 +663,17 @@ def print_plan_details(plan_entry: PlanEntry) -> None:
             action_text = (
                 f"({action_color}⛔ {action_label}{Colors.ENDC})"
                 if USE_COLORS
-                else f"[{action_label}]"
+                else f"[⛔ {action_label}]"
             )
 
+        bullet = "•" if USE_COLORS else "-"
         if USE_COLORS:
             print(
-                f"  • {Colors.BOLD}{name:<{max_name_len}}{Colors.ENDC} : {formatted_rules:>{max_rules_len}} rules {action_text}"
+                f"  {bullet} {Colors.BOLD}{name:<{max_name_len}}{Colors.ENDC} : {formatted_rules:>{max_rules_len}} rules {action_text}"
             )
         else:
             print(
-                f"  - {name:<{max_name_len}} : {formatted_rules:>{max_rules_len}} rules {action_text}"
+                f"  {bullet} {name:<{max_name_len}} : {formatted_rules:>{max_rules_len}} rules {action_text}"
             )
 
     print("")
@@ -2729,9 +2730,6 @@ def print_summary_table(
 
 def print_success_message(profile_ids: list[str]) -> None:
     """Prints a random success message and a link to the Control D dashboard."""
-    if not USE_COLORS:
-        return
-
     success_msgs = [
         "✨ All synced!",
         "🚀 Ready for liftoff!",
@@ -2739,7 +2737,10 @@ def print_success_message(profile_ids: list[str]) -> None:
         "💎 Smooth operation!",
         "🌈 Perfect harmony!",
     ]
-    print(f"\n{Colors.GREEN}{random.choice(success_msgs)}{Colors.ENDC}")
+    if USE_COLORS:
+        print(f"\n{Colors.GREEN}{random.choice(success_msgs)}{Colors.ENDC}")
+    else:
+        print(f"\n{random.choice(success_msgs)}")
 
     # Construct dashboard URL
     if (
@@ -2750,14 +2751,20 @@ def print_success_message(profile_ids: list[str]) -> None:
         dashboard_url = (
             f"https://controld.com/dashboard/profiles/{profile_ids[0]}/filters"
         )
-        print(
-            f"{Colors.CYAN}👀 View your changes: {Colors.UNDERLINE}{dashboard_url}{Colors.ENDC}"
-        )
+        if USE_COLORS:
+            print(
+                f"{Colors.CYAN}👀 View your changes: {Colors.UNDERLINE}{dashboard_url}{Colors.ENDC}"
+            )
+        else:
+            print(f"👀 View your changes: {dashboard_url}")
     elif len(profile_ids) > 1:
         dashboard_url = "https://controld.com/dashboard/profiles"
-        print(
-            f"{Colors.CYAN}👀 View your changes: {Colors.UNDERLINE}{dashboard_url}{Colors.ENDC}"
-        )
+        if USE_COLORS:
+            print(
+                f"{Colors.CYAN}👀 View your changes: {Colors.UNDERLINE}{dashboard_url}{Colors.ENDC}"
+            )
+        else:
+            print(f"👀 View your changes: {dashboard_url}")
 
 
 def parse_args() -> argparse.Namespace:

--- a/main.py
+++ b/main.py
@@ -2743,28 +2743,28 @@ def print_success_message(profile_ids: list[str]) -> None:
         print(f"\n{random.choice(success_msgs)}")
 
     # Construct dashboard URL
-    if (
-        profile_ids
+    is_single_profile = (
+        bool(profile_ids)
         and len(profile_ids) == 1
         and profile_ids[0] != "dry-run-placeholder"
-    ):
+    )
+    is_multi_profile = len(profile_ids) > 1
+
+    if is_single_profile:
         dashboard_url = (
             f"https://controld.com/dashboard/profiles/{profile_ids[0]}/filters"
         )
-        if USE_COLORS:
-            print(
-                f"{Colors.CYAN}👀 View your changes: {Colors.UNDERLINE}{dashboard_url}{Colors.ENDC}"
-            )
-        else:
-            print(f"👀 View your changes: {dashboard_url}")
-    elif len(profile_ids) > 1:
+    elif is_multi_profile:
         dashboard_url = "https://controld.com/dashboard/profiles"
-        if USE_COLORS:
-            print(
-                f"{Colors.CYAN}👀 View your changes: {Colors.UNDERLINE}{dashboard_url}{Colors.ENDC}"
-            )
-        else:
-            print(f"👀 View your changes: {dashboard_url}")
+    else:
+        return
+
+    if USE_COLORS:
+        print(
+            f"{Colors.CYAN}👀 View your changes: {Colors.UNDERLINE}{dashboard_url}{Colors.ENDC}"
+        )
+    else:
+        print(f"👀 View your changes: {dashboard_url}")
 
 
 def parse_args() -> argparse.Namespace:

--- a/tests/test_plan_details.py
+++ b/tests/test_plan_details.py
@@ -31,11 +31,11 @@ def test_print_plan_details_no_colors(capsys):
     captured = capsys.readouterr()
     output = captured.out
 
-    assert "Plan Details for test_profile:" in output
+    assert "📝 Plan Details for test_profile:" in output
     # Match exact output including alignment spaces
-    assert "  - Folder A : 10 rules [Allow]" in output
-    assert "  - Folder B :  5 rules [Block]" in output
-    assert "  - Folder C :  3 rules [Mixed]" in output
+    assert "  - Folder A : 10 rules [✅ Allow]" in output
+    assert "  - Folder B :  5 rules [⛔ Block]" in output
+    assert "  - Folder C :  3 rules [⚠️  Mixed]" in output
     # Verify alphabetical ordering (A before B before C)
     assert output.index("Folder A") < output.index("Folder B")
     assert output.index("Folder B") < output.index("Folder C")
@@ -52,9 +52,9 @@ def test_print_plan_details_empty_folders(capsys):
     captured = capsys.readouterr()
     output = captured.out
 
-    assert "Plan Details for test_profile:" in output
-    assert "No folders to sync." in output
-    assert "Hint: Add folder URLs using --folder-url or in your config.yaml" in output
+    assert "📝 Plan Details for test_profile:" in output
+    assert "⚠️  No folders to sync." in output
+    assert "💡 Hint: Add folder URLs using --folder-url or in your config.yaml" in output
 
 
 def test_print_plan_details_with_colors(capsys):

--- a/tests/test_plan_details.py
+++ b/tests/test_plan_details.py
@@ -53,8 +53,8 @@ def test_print_plan_details_empty_folders(capsys):
     output = captured.out
 
     assert "📝 Plan Details for test_profile:" in output
-    assert "⚠️  No folders to sync." in output
-    assert "💡 Hint: Add folder URLs using --folder-url or in your config.yaml" in output
+    assert "  ⚠️  No folders to sync." in output
+    assert "  💡 Hint: Add folder URLs using --folder-url or in your config.yaml" in output
 
 
 def test_print_plan_details_with_colors(capsys):

--- a/tests/test_ux.py
+++ b/tests/test_ux.py
@@ -142,14 +142,18 @@ def test_print_success_message_multiple_profiles(monkeypatch):
 
 
 def test_print_success_message_no_colors(monkeypatch):
-    """Verify nothing is printed if colors are disabled."""
+    """Verify uncolored success message is printed if colors are disabled."""
     monkeypatch.setattr(main, "USE_COLORS", False)
     mock_stdout = MagicMock()
     monkeypatch.setattr(sys, "stdout", mock_stdout)
 
     main.print_success_message(["123"])
 
-    mock_stdout.write.assert_not_called()
+    writes = [args[0] for args, _ in mock_stdout.write.call_args_list]
+    combined_output = "".join(writes)
+
+    assert "View your changes" in combined_output
+    assert "https://controld.com/dashboard/profiles/123/filters" in combined_output
 
 
 class TestGetProgressBarWidth:


### PR DESCRIPTION
💡 What: Modified `print_plan_details` and `print_success_message` to print uncolored text blocks with emojis instead of removing them altogether when `USE_COLORS` is `False`.
🎯 Why: Completely suppressing output blocks or emojis limits the UX for `NO_COLOR` users (e.g. they don't see dashboard links or actionable states), and relying on stripping logic broke terminal formatting.
📸 Before/After: n/a
♿ Accessibility: Ensures non-tty and accessible terminal clients still receive helpful semantic feedback and call-to-actions, even if color is disabled.

---
*PR created automatically by Jules for task [6508302327423398903](https://jules.google.com/task/6508302327423398903) started by @abhimehro*