### PR TITLE
🎨 Palette: Preserve semantic emojis in no-color fallback mode

### DIFF
--- a/main.py
+++ b/main.py
@@ -576,16 +576,16 @@ def print_plan_details(plan_entry: PlanEntry) -> None:
     if USE_COLORS:
         print(f"\n{Colors.HEADER}📝 Plan Details for {profile}:{Colors.ENDC}")
     else:
-        print(f"\nPlan Details for {profile}:")
+        print(f"\n📝 Plan Details for {profile}:")
 
     if not folders:
         if USE_COLORS:
-            print(f"  {Colors.WARNING}No folders to sync.{Colors.ENDC}")
+            print(f"  {Colors.WARNING}⚠️  No folders to sync.{Colors.ENDC}")
             print(
                 f"  {Colors.DIM}💡 Hint: Add folder URLs using --folder-url or in your config.yaml{Colors.ENDC}"
             )
         else:
-            print("  No folders to sync.")
+            print("  ⚠️  No folders to sync.")
             print("  💡 Hint: Add folder URLs using --folder-url or in your config.yaml")
         return
 
@@ -616,7 +616,7 @@ def print_plan_details(plan_entry: PlanEntry) -> None:
                 action_text = (
                     f"({action_color}⚠️  {action_label}{Colors.ENDC})"
                     if USE_COLORS
-                    else f"[{action_label}]"
+                    else f"[⚠️  {action_label}]"
                 )
             else:
                 # All groups have same action
@@ -627,7 +627,7 @@ def print_plan_details(plan_entry: PlanEntry) -> None:
                     action_text = (
                         f"({action_color}⛔ {action_label}{Colors.ENDC})"
                         if USE_COLORS
-                        else f"[{action_label}]"
+                        else f"[⛔ {action_label}]"
                     )
                 elif action_val == 1:
                     action_label = "Allow"
@@ -635,7 +635,7 @@ def print_plan_details(plan_entry: PlanEntry) -> None:
                     action_text = (
                         f"({action_color}✅ {action_label}{Colors.ENDC})"
                         if USE_COLORS
-                        else f"[{action_label}]"
+                        else f"[✅ {action_label}]"
                     )
 
         # Fallback to single action if not set
@@ -647,7 +647,7 @@ def print_plan_details(plan_entry: PlanEntry) -> None:
                 action_text = (
                     f"({action_color}⛔ {action_label}{Colors.ENDC})"
                     if USE_COLORS
-                    else f"[{action_label}]"
+                    else f"[⛔ {action_label}]"
                 )
             elif action_val == 1:
                 action_label = "Allow"
@@ -655,7 +655,7 @@ def print_plan_details(plan_entry: PlanEntry) -> None:
                 action_text = (
                     f"({action_color}✅ {action_label}{Colors.ENDC})"
                     if USE_COLORS
-                    else f"[{action_label}]"
+                    else f"[✅ {action_label}]"
                 )
 
         # If action is still completely missing/unknown, default to Block (Default) for clearer UX
@@ -665,7 +665,7 @@ def print_plan_details(plan_entry: PlanEntry) -> None:
             action_text = (
                 f"({action_color}⛔ {action_label}{Colors.ENDC})"
                 if USE_COLORS
-                else f"[{action_label}]"
+                else f"[⛔ {action_label}]"
             )
 
         if USE_COLORS:

--- a/tests/test_plan_details.py
+++ b/tests/test_plan_details.py
@@ -31,11 +31,11 @@ def test_print_plan_details_no_colors(capsys):
     captured = capsys.readouterr()
     output = captured.out
 
-    assert "Plan Details for test_profile:" in output
+    assert "📝 Plan Details for test_profile:" in output
     # Match exact output including alignment spaces
-    assert "  - Folder A : 10 rules [Allow]" in output
-    assert "  - Folder B :  5 rules [Block]" in output
-    assert "  - Folder C :  3 rules [Mixed]" in output
+    assert "  - Folder A : 10 rules [✅ Allow]" in output
+    assert "  - Folder B :  5 rules [⛔ Block]" in output
+    assert "  - Folder C :  3 rules [⚠️  Mixed]" in output
     # Verify alphabetical ordering (A before B before C)
     assert output.index("Folder A") < output.index("Folder B")
     assert output.index("Folder B") < output.index("Folder C")
@@ -52,8 +52,8 @@ def test_print_plan_details_empty_folders(capsys):
     captured = capsys.readouterr()
     output = captured.out
 
-    assert "Plan Details for test_profile:" in output
-    assert "No folders to sync." in output
+    assert "📝 Plan Details for test_profile:" in output
+    assert "  ⚠️  No folders to sync." in output
     assert "Hint: Add folder URLs using --folder-url or in your config.yaml" in output
 
 


### PR DESCRIPTION
- Updated `print_plan_details` in `main.py` to use explicit `if/else` logic for non-colored output, ensuring semantic emojis (📝, ⚠️, ⛔, ✅) are preserved when `USE_COLORS` is false or `NO_COLOR=1` is set.
- Ensured consistency with the "No-Color Fallbacks for Delight" UX standard, preventing the complete suppression of helpful visual cues in CI or accessibility environments.
- Updated relevant test assertions in `tests/test_plan_details.py` to match the new strings.

---
*PR created automatically by Jules for task [3243423561181406493](https://jules.google.com/task/3243423561181406493) started by @abhimehro*