### PR TITLE
🎨 Palette: Retain semantic emojis in NO_COLOR fallbacks

### DIFF
--- a/main.py
+++ b/main.py
@@ -580,12 +580,12 @@ def print_plan_details(plan_entry: PlanEntry) -> None:
 
     if not folders:
         if USE_COLORS:
-            print(f"  {Colors.WARNING}No folders to sync.{Colors.ENDC}")
+            print(f"  {Colors.WARNING}⚠️  No folders to sync.{Colors.ENDC}")
             print(
                 f"  {Colors.DIM}💡 Hint: Add folder URLs using --folder-url or in your config.yaml{Colors.ENDC}"
             )
         else:
-            print("  No folders to sync.")
+            print("  ⚠️  No folders to sync.")
             print(
                 "  💡 Hint: Add folder URLs using --folder-url or in your config.yaml"
             )
@@ -618,7 +618,7 @@ def print_plan_details(plan_entry: PlanEntry) -> None:
                 action_text = (
                     f"({action_color}⚠️  {action_label}{Colors.ENDC})"
                     if USE_COLORS
-                    else f"[{action_label}]"
+                    else f"(⚠️  {action_label})"
                 )
             else:
                 # All groups have same action
@@ -629,7 +629,7 @@ def print_plan_details(plan_entry: PlanEntry) -> None:
                     action_text = (
                         f"({action_color}⛔ {action_label}{Colors.ENDC})"
                         if USE_COLORS
-                        else f"[{action_label}]"
+                        else f"(⛔ {action_label})"
                     )
                 elif action_val == 1:
                     action_label = "Allow"
@@ -637,7 +637,7 @@ def print_plan_details(plan_entry: PlanEntry) -> None:
                     action_text = (
                         f"({action_color}✅ {action_label}{Colors.ENDC})"
                         if USE_COLORS
-                        else f"[{action_label}]"
+                        else f"(✅ {action_label})"
                     )
 
         # Fallback to single action if not set
@@ -649,7 +649,7 @@ def print_plan_details(plan_entry: PlanEntry) -> None:
                 action_text = (
                     f"({action_color}⛔ {action_label}{Colors.ENDC})"
                     if USE_COLORS
-                    else f"[{action_label}]"
+                    else f"(⛔ {action_label})"
                 )
             elif action_val == 1:
                 action_label = "Allow"
@@ -657,7 +657,7 @@ def print_plan_details(plan_entry: PlanEntry) -> None:
                 action_text = (
                     f"({action_color}✅ {action_label}{Colors.ENDC})"
                     if USE_COLORS
-                    else f"[{action_label}]"
+                    else f"(✅ {action_label})"
                 )
 
         # If action is still completely missing/unknown, default to Block (Default) for clearer UX
@@ -667,7 +667,7 @@ def print_plan_details(plan_entry: PlanEntry) -> None:
             action_text = (
                 f"({action_color}⛔ {action_label}{Colors.ENDC})"
                 if USE_COLORS
-                else f"[{action_label}]"
+                else f"(⛔ {action_label})"
             )
 
         if USE_COLORS:
@@ -709,9 +709,11 @@ def countdown_timer(seconds: int, message: str = "Waiting") -> None:
 
                 sleep_time = min(step, remaining)
                 time.sleep(sleep_time)
+            log.info(f"✅ {sanitize_for_log(message)}: Done!")
             return
 
         time.sleep(seconds)
+        log.info(f"✅ {sanitize_for_log(message)}: Done!")
         return
 
     width = _get_progress_bar_width()
@@ -1983,6 +1985,8 @@ def warm_up_cache(urls: Sequence[str]) -> None:
             f"\r\033[K{Colors.GREEN}✅ Warming up cache: Done!{Colors.ENDC}\n"
         )
         sys.stderr.flush()
+    else:
+        log.info("✅ Warming up cache: Done!")
 
 
 def delete_folder(
@@ -2291,7 +2295,7 @@ def push_rules(
             sys.stderr.flush()
         else:
             log.info(
-                f"Folder {sanitize_for_log(folder_name)} – finished ({len(filtered_hostnames):,} new rules added)"
+                f"✅ Folder {sanitize_for_log(folder_name)}: Finished ({len(filtered_hostnames):,} new rules added)"
             )
         return True
     if USE_COLORS:
@@ -2641,13 +2645,19 @@ def prompt_for_interactive_restart(profile_ids: list[str]) -> None:
         if "--profiles" not in sys.argv and profile_ids:
             new_argv.extend(["--profiles", ",".join(profile_ids)])
 
-        print(f"\n{Colors.GREEN}🔄 Restarting in live mode...{Colors.ENDC}")
+        if USE_COLORS:
+            print(f"\n{Colors.GREEN}🔄 Restarting in live mode...{Colors.ENDC}")
+        else:
+            print("\n🔄 Restarting in live mode...")
         # Security: The input to execv is derived from trusted sys.argv and validated profile_ids.
         # It restarts the same script with the same python interpreter.
         os.execv(sys.executable, new_argv)  # nosec B606
 
     except (KeyboardInterrupt, EOFError):
-        print(f"\n{Colors.WARNING}⚠️  Cancelled.{Colors.ENDC}")
+        if USE_COLORS:
+            print(f"\n{Colors.WARNING}⚠️  Cancelled.{Colors.ENDC}")
+        else:
+            print("\n⚠️  Cancelled.")
 
 
 def print_line(left_char: str, mid_char: str, right_char: str, w: list[int]) -> str:

--- a/tests/test_plan_details.py
+++ b/tests/test_plan_details.py
@@ -33,9 +33,9 @@ def test_print_plan_details_no_colors(capsys):
 
     assert "Plan Details for test_profile:" in output
     # Match exact output including alignment spaces
-    assert "  - Folder A : 10 rules [Allow]" in output
-    assert "  - Folder B :  5 rules [Block]" in output
-    assert "  - Folder C :  3 rules [Mixed]" in output
+    assert "  - Folder A : 10 rules (✅ Allow)" in output
+    assert "  - Folder B :  5 rules (⛔ Block)" in output
+    assert "  - Folder C :  3 rules (⚠️  Mixed)" in output
     # Verify alphabetical ordering (A before B before C)
     assert output.index("Folder A") < output.index("Folder B")
     assert output.index("Folder B") < output.index("Folder C")

--- a/tests/test_ux.py
+++ b/tests/test_ux.py
@@ -48,8 +48,8 @@ def test_countdown_timer_no_colors_short(monkeypatch):
 
     main.countdown_timer(10, "Test")
 
-    # Should not log
-    mock_log.info.assert_not_called()
+    # Should log completion
+    mock_log.info.assert_called_once_with("✅ Test: Done!")
     # Should call sleep exactly once with full seconds
     mock_sleep.assert_called_once_with(10)
     # Should not write anything to stderr for short, no-color countdowns
@@ -77,14 +77,16 @@ def test_countdown_timer_no_colors_long(monkeypatch):
     # Expected log calls:
     # 1. "LongWait: 15s remaining..." (after first sleep/loop iteration)
     # 2. "LongWait: 5s remaining..." (after second sleep/loop iteration)
+    # 3. "✅ LongWait: Done!" (at the end)
 
     assert mock_sleep.call_count == 3
     mock_sleep.assert_any_call(10)
     mock_sleep.assert_any_call(5)
 
-    assert mock_log.info.call_count == 2
+    assert mock_log.info.call_count == 3
     mock_log.info.assert_any_call("LongWait: 15s remaining...")
     mock_log.info.assert_any_call("LongWait: 5s remaining...")
+    mock_log.info.assert_any_call("✅ LongWait: Done!")
 
 
 def test_print_success_message_single_profile(monkeypatch):


### PR DESCRIPTION
As Palette, I focused on improving the CLI user experience in restricted environments (such as CI systems, environments with NO_COLOR=1, or for users relying on screen readers where text cues are preferred over ANSI color codes).

Previously, when the script correctly disabled ANSI colors, it often threw out the baby with the bathwater by also stripping out helpful semantic emojis (like ✅, ⛔, ⚠️) from the fallback text. This left users with bland, less scannable logs. 

I've updated `main.py` so that functions outputting statuses or prompts now retain their semantic emojis regardless of whether the text is colored. I also made sure to update our Pytest suite (`test_ux.py`, `test_plan_details.py`) to expect these emojis so everything passes cleanly.

💡 What: Retained semantic emojis in NO_COLOR fallback branches.
🎯 Why: To ensure users in non-interactive/CI environments or those with visual impairments still receive clear, scannable visual indicators of state (Success, Blocked, Warning, Loading).
📸 Before/After: In `NO_COLOR=1` dry runs, `  - Folder B :  5 rules [Block]` becomes `  - Folder B :  5 rules (⛔ Block)`. Long waits now terminate with `✅ Waiting: Done!` instead of ending silently.
♿ Accessibility: Improves visual scannability for users who may have color vision deficiencies, ensuring they don't have to rely purely on ANSI color coding to understand operation status.

---
*PR created automatically by Jules for task [3314906473231119260](https://jules.google.com/task/3314906473231119260) started by @abhimehro*