### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF loopback bypass

### DIFF
--- a/main.py
+++ b/main.py
@@ -1062,10 +1062,14 @@ _CGNAT_NETWORK = ipaddress.IPv4Network("100.64.0.0/10")
 
 
 def _is_safe_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
-    """Rejects multicast, unspecified, and IPv4 CGNAT addresses; otherwise requires a global IP."""
+    """Rejects multicast, unspecified, loopback, link-local, and IPv4 CGNAT addresses; otherwise requires a global IP."""
     if ip.is_multicast:
         return False
     if ip.is_unspecified:
+        return False
+    if ip.is_loopback:
+        return False
+    if ip.is_link_local:
         return False
     if ip.is_private:
         return False

--- a/payload.json
+++ b/payload.json
@@ -1,0 +1,6 @@
+{
+  "title": "🛡️ Sentinel: [HIGH] Fix SSRF loopback bypass",
+  "head": "jules-2847833434788904308-422ff337",
+  "base": "main",
+  "body": "🚨 Severity: HIGH\n💡 Vulnerability: SSRF loopback and link-local IP bypass\n🎯 Impact: An attacker could bypass the SSRF filter to access internal services via domains resolving to loopback or link-local IPs\n🔧 Fix: Explicitly check for and block loopback and link-local IPs using `ip.is_loopback` and `ip.is_link_local` in `_is_safe_ip`\n✅ Verification: Verify by running `pytest tests/test_ssrf_enhanced.py`"
+}


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: SSRF loopback and link-local IP bypass
🎯 Impact: An attacker could bypass the SSRF filter to access internal services via domains resolving to loopback or link-local IPs
🔧 Fix: Explicitly check for and block loopback and link-local IPs using `ip.is_loopback` and `ip.is_link_local` in `_is_safe_ip`
✅ Verification: Verify by running `pytest tests/test_ssrf_enhanced.py`

---
*PR created automatically by Jules for task [2847833434788904308](https://jules.google.com/task/2847833434788904308) started by @abhimehro*