### PR TITLE
🎨 Palette: Fix CLI color fallback UX for generic input prompts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -46,3 +46,7 @@
 ## 2025-04-12 - [Semantic Color Fallback Validation]
 **Learning:** When conditionalizing color output (`USE_COLORS`) for accessibility and text-only UI environments, applying fallback UI to input functions requires explicit `if/else` checks rather than concatenating empty ANSI constants dynamically.
 **Action:** Use pure fallback string constants stripped of any embedded color codes, to prevent visually "swallowing" emojis or breaking fallback display formatting.
+
+## 2025-04-12 - [Code Health in UI Handlers]
+**Learning:** Adding explicit conditional blocks (`if USE_COLORS`) directly inside generic input/output handler functions quickly inflates cyclomatic complexity, triggering Code Health violations (like CodeScene's "Bumpy Road Ahead" or "Complex Method" warnings).
+**Action:** Always extract conditionally-formatted CLI output logic into dedicated module-level helper functions (e.g., `_print_error_with_hint`) to preserve clean code health while enabling accessible fallbacks.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -42,3 +42,7 @@
 
 **Learning:** While intercepting strings like "n" or "no" for cancellation in interactive boolean prompts (e.g., "Ready to launch?") is good UX, applying this same interception logic universally to *generic* input functions (like `get_validated_input` or `get_password`) introduces severe functional and security regressions. A user whose valid answer is "no" or whose password happens to match a cancellation string will be unexpectedly booted from the application.
 **Action:** Confine string-based cancellation interception to specific, appropriate contexts (like interactive confirmations). For generic input and password fields, rely solely on standard interrupt signals (Ctrl+C / Ctrl+D).
+
+## 2025-04-12 - [Semantic Color Fallback Validation]
+**Learning:** When conditionalizing color output (`USE_COLORS`) for accessibility and text-only UI environments, applying fallback UI to input functions requires explicit `if/else` checks rather than concatenating empty ANSI constants dynamically.
+**Action:** Use pure fallback string constants stripped of any embedded color codes, to prevent visually "swallowing" emojis or breaking fallback display formatting.

--- a/main.py
+++ b/main.py
@@ -461,8 +461,8 @@ log = logging.getLogger("control-d-sync")
 API_BASE = "https://api.controld.com/profiles"
 USER_AGENT = "Control-D-Sync/0.1.0"
 
-EMPTY_INPUT_HINT = f"   {Colors.DIM}💡 Hint: Please type a value and press Enter, or press Ctrl+C/Ctrl+D to cancel.{Colors.ENDC}"
-INVALID_INPUT_HINT = f"   {Colors.DIM}💡 Hint: Please check your input and try again, or press Ctrl+C/Ctrl+D to cancel.{Colors.ENDC}"
+EMPTY_INPUT_HINT = "   💡 Hint: Please type a value and press Enter, or press Ctrl+C/Ctrl+D to cancel."
+INVALID_INPUT_HINT = "   💡 Hint: Please check your input and try again, or press Ctrl+C/Ctrl+D to cancel."
 
 # Pre-compiled regex patterns for hot-path validation (>2x speedup on 10k+ items)
 PROFILE_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
@@ -782,19 +782,30 @@ def get_validated_input(
             sys.stderr.flush()
             value = input(prompt).strip()
         except (KeyboardInterrupt, EOFError):
-            print(f"\n{Colors.WARNING}⚠️  Input cancelled.{Colors.ENDC}")
+            if USE_COLORS:
+                print(f"\n{Colors.WARNING}⚠️  Input cancelled.{Colors.ENDC}")
+            else:
+                print("\n⚠️  Input cancelled.")
             sys.exit(130)
 
         if not value:
-            print(f"{Colors.FAIL}❌ Value cannot be empty{Colors.ENDC}")
-            print(EMPTY_INPUT_HINT)
+            if USE_COLORS:
+                print(f"{Colors.FAIL}❌ Value cannot be empty{Colors.ENDC}")
+                print(f"{Colors.DIM}{EMPTY_INPUT_HINT}{Colors.ENDC}")
+            else:
+                print("❌ Value cannot be empty")
+                print(EMPTY_INPUT_HINT)
             continue
 
         if validator(value):
             return value
 
-        print(f"{Colors.FAIL}❌ {error_msg}{Colors.ENDC}")
-        print(INVALID_INPUT_HINT)
+        if USE_COLORS:
+            print(f"{Colors.FAIL}❌ {error_msg}{Colors.ENDC}")
+            print(f"{Colors.DIM}{INVALID_INPUT_HINT}{Colors.ENDC}")
+        else:
+            print(f"❌ {error_msg}")
+            print(INVALID_INPUT_HINT)
 
 
 def get_password(
@@ -812,19 +823,30 @@ def get_password(
             sys.stderr.flush()
             value = getpass.getpass(prompt).strip()
         except (KeyboardInterrupt, EOFError):
-            print(f"\n{Colors.WARNING}⚠️  Input cancelled.{Colors.ENDC}")
+            if USE_COLORS:
+                print(f"\n{Colors.WARNING}⚠️  Input cancelled.{Colors.ENDC}")
+            else:
+                print("\n⚠️  Input cancelled.")
             sys.exit(130)
 
         if not value:
-            print(f"{Colors.FAIL}❌ Value cannot be empty{Colors.ENDC}")
-            print(EMPTY_INPUT_HINT)
+            if USE_COLORS:
+                print(f"{Colors.FAIL}❌ Value cannot be empty{Colors.ENDC}")
+                print(f"{Colors.DIM}{EMPTY_INPUT_HINT}{Colors.ENDC}")
+            else:
+                print("❌ Value cannot be empty")
+                print(EMPTY_INPUT_HINT)
             continue
 
         if validator(value):
             return value
 
-        print(f"{Colors.FAIL}❌ {error_msg}{Colors.ENDC}")
-        print(INVALID_INPUT_HINT)
+        if USE_COLORS:
+            print(f"{Colors.FAIL}❌ {error_msg}{Colors.ENDC}")
+            print(f"{Colors.DIM}{INVALID_INPUT_HINT}{Colors.ENDC}")
+        else:
+            print(f"❌ {error_msg}")
+            print(INVALID_INPUT_HINT)
 
 
 TOKEN = _clean_env_kv(os.getenv("TOKEN"), "TOKEN")

--- a/main.py
+++ b/main.py
@@ -767,6 +767,24 @@ def _clean_env_kv(value: str | None, key: str) -> str | None:
     return v
 
 
+def _print_cancel_warning() -> None:
+    """Prints an input cancellation warning to standard output."""
+    if USE_COLORS:
+        print(f"\n{Colors.WARNING}⚠️  Input cancelled.{Colors.ENDC}")
+    else:
+        print("\n⚠️  Input cancelled.")
+
+
+def _print_error_with_hint(error_msg: str, hint_msg: str) -> None:
+    """Prints an error message and a secondary hint to standard output."""
+    if USE_COLORS:
+        print(f"{Colors.FAIL}❌ {error_msg}{Colors.ENDC}")
+        print(f"{Colors.DIM}{hint_msg}{Colors.ENDC}")
+    else:
+        print(f"❌ {error_msg}")
+        print(hint_msg)
+
+
 def get_validated_input(
     prompt: str,
     validator: Callable[[str], bool],
@@ -782,30 +800,17 @@ def get_validated_input(
             sys.stderr.flush()
             value = input(prompt).strip()
         except (KeyboardInterrupt, EOFError):
-            if USE_COLORS:
-                print(f"\n{Colors.WARNING}⚠️  Input cancelled.{Colors.ENDC}")
-            else:
-                print("\n⚠️  Input cancelled.")
+            _print_cancel_warning()
             sys.exit(130)
 
         if not value:
-            if USE_COLORS:
-                print(f"{Colors.FAIL}❌ Value cannot be empty{Colors.ENDC}")
-                print(f"{Colors.DIM}{EMPTY_INPUT_HINT}{Colors.ENDC}")
-            else:
-                print("❌ Value cannot be empty")
-                print(EMPTY_INPUT_HINT)
+            _print_error_with_hint("Value cannot be empty", EMPTY_INPUT_HINT)
             continue
 
         if validator(value):
             return value
 
-        if USE_COLORS:
-            print(f"{Colors.FAIL}❌ {error_msg}{Colors.ENDC}")
-            print(f"{Colors.DIM}{INVALID_INPUT_HINT}{Colors.ENDC}")
-        else:
-            print(f"❌ {error_msg}")
-            print(INVALID_INPUT_HINT)
+        _print_error_with_hint(error_msg, INVALID_INPUT_HINT)
 
 
 def get_password(
@@ -823,30 +828,17 @@ def get_password(
             sys.stderr.flush()
             value = getpass.getpass(prompt).strip()
         except (KeyboardInterrupt, EOFError):
-            if USE_COLORS:
-                print(f"\n{Colors.WARNING}⚠️  Input cancelled.{Colors.ENDC}")
-            else:
-                print("\n⚠️  Input cancelled.")
+            _print_cancel_warning()
             sys.exit(130)
 
         if not value:
-            if USE_COLORS:
-                print(f"{Colors.FAIL}❌ Value cannot be empty{Colors.ENDC}")
-                print(f"{Colors.DIM}{EMPTY_INPUT_HINT}{Colors.ENDC}")
-            else:
-                print("❌ Value cannot be empty")
-                print(EMPTY_INPUT_HINT)
+            _print_error_with_hint("Value cannot be empty", EMPTY_INPUT_HINT)
             continue
 
         if validator(value):
             return value
 
-        if USE_COLORS:
-            print(f"{Colors.FAIL}❌ {error_msg}{Colors.ENDC}")
-            print(f"{Colors.DIM}{INVALID_INPUT_HINT}{Colors.ENDC}")
-        else:
-            print(f"❌ {error_msg}")
-            print(INVALID_INPUT_HINT)
+        _print_error_with_hint(error_msg, INVALID_INPUT_HINT)
 
 
 TOKEN = _clean_env_kv(os.getenv("TOKEN"), "TOKEN")


### PR DESCRIPTION
💡 What: Refactored generic input hint printing to use explicit `if USE_COLORS` conditions rather than embedded empty string constants.
🎯 Why: Fixes a UX issue where fallback text (like semantic emojis) might be inadvertently lost or improperly formatted when `NO_COLOR=1` is used.
📸 Before/After: None (terminal output parity).
♿ Accessibility: Improved semantic clarity in text-only terminals.

---
*PR created automatically by Jules for task [14339738001532003484](https://jules.google.com/task/14339738001532003484) started by @abhimehro*