### PR TITLE
ux: Fix colored hint constants leaking ANSI codes

### DIFF
--- a/main.py
+++ b/main.py
@@ -769,6 +769,16 @@ def _clean_env_kv(value: str | None, key: str) -> str | None:
     return v
 
 
+def _print_input_error(error_msg: str, hint: str) -> None:
+    """Helper to conditionally format and print input error messages and hints."""
+    if USE_COLORS:
+        print(f"{Colors.FAIL}❌ {error_msg}{Colors.ENDC}")
+        print(f"{Colors.DIM}{hint}{Colors.ENDC}")
+    else:
+        print(f"❌ {error_msg}")
+        print(hint)
+
+
 def get_validated_input(
     prompt: str,
     validator: Callable[[str], bool],
@@ -788,23 +798,13 @@ def get_validated_input(
             sys.exit(130)
 
         if not value:
-            if USE_COLORS:
-                print(f"{Colors.FAIL}❌ Value cannot be empty{Colors.ENDC}")
-                print(f"{Colors.DIM}{EMPTY_INPUT_HINT}{Colors.ENDC}")
-            else:
-                print("❌ Value cannot be empty")
-                print(EMPTY_INPUT_HINT)
+            _print_input_error("Value cannot be empty", EMPTY_INPUT_HINT)
             continue
 
         if validator(value):
             return value
 
-        if USE_COLORS:
-            print(f"{Colors.FAIL}❌ {error_msg}{Colors.ENDC}")
-            print(f"{Colors.DIM}{INVALID_INPUT_HINT}{Colors.ENDC}")
-        else:
-            print(f"❌ {error_msg}")
-            print(INVALID_INPUT_HINT)
+        _print_input_error(error_msg, INVALID_INPUT_HINT)
 
 
 def get_password(
@@ -826,23 +826,13 @@ def get_password(
             sys.exit(130)
 
         if not value:
-            if USE_COLORS:
-                print(f"{Colors.FAIL}❌ Value cannot be empty{Colors.ENDC}")
-                print(f"{Colors.DIM}{EMPTY_INPUT_HINT}{Colors.ENDC}")
-            else:
-                print("❌ Value cannot be empty")
-                print(EMPTY_INPUT_HINT)
+            _print_input_error("Value cannot be empty", EMPTY_INPUT_HINT)
             continue
 
         if validator(value):
             return value
 
-        if USE_COLORS:
-            print(f"{Colors.FAIL}❌ {error_msg}{Colors.ENDC}")
-            print(f"{Colors.DIM}{INVALID_INPUT_HINT}{Colors.ENDC}")
-        else:
-            print(f"❌ {error_msg}")
-            print(INVALID_INPUT_HINT)
+        _print_input_error(error_msg, INVALID_INPUT_HINT)
 
 
 TOKEN = _clean_env_kv(os.getenv("TOKEN"), "TOKEN")

--- a/main.py
+++ b/main.py
@@ -461,8 +461,10 @@ log = logging.getLogger("control-d-sync")
 API_BASE = "https://api.controld.com/profiles"
 USER_AGENT = "Control-D-Sync/0.1.0"
 
-EMPTY_INPUT_HINT = f"   {Colors.DIM}💡 Hint: Please type a value and press Enter, or press Ctrl+C/Ctrl+D to cancel.{Colors.ENDC}"
-INVALID_INPUT_HINT = f"   {Colors.DIM}💡 Hint: Please check your input and try again, or press Ctrl+C/Ctrl+D to cancel.{Colors.ENDC}"
+EMPTY_INPUT_HINT = (
+    "   💡 Hint: Please type a value and press Enter, or press Ctrl+C/Ctrl+D to cancel."
+)
+INVALID_INPUT_HINT = "   💡 Hint: Please check your input and try again, or press Ctrl+C/Ctrl+D to cancel."
 
 # Pre-compiled regex patterns for hot-path validation (>2x speedup on 10k+ items)
 PROFILE_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
@@ -786,15 +788,23 @@ def get_validated_input(
             sys.exit(130)
 
         if not value:
-            print(f"{Colors.FAIL}❌ Value cannot be empty{Colors.ENDC}")
-            print(EMPTY_INPUT_HINT)
+            if USE_COLORS:
+                print(f"{Colors.FAIL}❌ Value cannot be empty{Colors.ENDC}")
+                print(f"{Colors.DIM}{EMPTY_INPUT_HINT}{Colors.ENDC}")
+            else:
+                print("❌ Value cannot be empty")
+                print(EMPTY_INPUT_HINT)
             continue
 
         if validator(value):
             return value
 
-        print(f"{Colors.FAIL}❌ {error_msg}{Colors.ENDC}")
-        print(INVALID_INPUT_HINT)
+        if USE_COLORS:
+            print(f"{Colors.FAIL}❌ {error_msg}{Colors.ENDC}")
+            print(f"{Colors.DIM}{INVALID_INPUT_HINT}{Colors.ENDC}")
+        else:
+            print(f"❌ {error_msg}")
+            print(INVALID_INPUT_HINT)
 
 
 def get_password(
@@ -816,15 +826,23 @@ def get_password(
             sys.exit(130)
 
         if not value:
-            print(f"{Colors.FAIL}❌ Value cannot be empty{Colors.ENDC}")
-            print(EMPTY_INPUT_HINT)
+            if USE_COLORS:
+                print(f"{Colors.FAIL}❌ Value cannot be empty{Colors.ENDC}")
+                print(f"{Colors.DIM}{EMPTY_INPUT_HINT}{Colors.ENDC}")
+            else:
+                print("❌ Value cannot be empty")
+                print(EMPTY_INPUT_HINT)
             continue
 
         if validator(value):
             return value
 
-        print(f"{Colors.FAIL}❌ {error_msg}{Colors.ENDC}")
-        print(INVALID_INPUT_HINT)
+        if USE_COLORS:
+            print(f"{Colors.FAIL}❌ {error_msg}{Colors.ENDC}")
+            print(f"{Colors.DIM}{INVALID_INPUT_HINT}{Colors.ENDC}")
+        else:
+            print(f"❌ {error_msg}")
+            print(INVALID_INPUT_HINT)
 
 
 TOKEN = _clean_env_kv(os.getenv("TOKEN"), "TOKEN")


### PR DESCRIPTION
- **Severity:** Low
- **Vulnerability:** Uncolored CLI output containing raw ANSI escape sequences when `USE_COLORS` is false
- **Impact:** Messy, broken output in CI/CD environments or when piped to a file
- **Fix:** Redefined global message constants (`EMPTY_INPUT_HINT`, `INVALID_INPUT_HINT`) as raw strings. Handled dynamic color insertion at the point of output inside `get_validated_input` and `get_password` using conditional checks.
- **Verification:** Ran `uv run pytest` successfully and tested with NO_COLOR simulation script.

---
*PR created automatically by Jules for task [16582690024641039024](https://jules.google.com/task/16582690024641039024) started by @abhimehro*