### PR TITLE
🎨 Palette: Consistently use _print_hint for UX hints

### DIFF
--- a/main.py
+++ b/main.py
@@ -583,14 +583,11 @@ def print_plan_details(plan_entry: PlanEntry) -> None:
     if not folders:
         if USE_COLORS:
             print(f"  {Colors.WARNING}⚠️  No folders to sync.{Colors.ENDC}")
-            print(
-                f"  {Colors.DIM}💡 Hint: Add folder URLs using --folder-url or in your config.yaml{Colors.ENDC}"
-            )
         else:
             print("  ⚠️  No folders to sync.")
-            print(
-                "  💡 Hint: Add folder URLs using --folder-url or in your config.yaml"
-            )
+        _print_hint(
+            "  💡 Hint: Add folder URLs using --folder-url or in your config.yaml"
+        )
         return
 
     # Calculate max width for alignment
@@ -2872,8 +2869,8 @@ def main() -> None:
                 exit(1)
         else:
             print(f"{Colors.CYAN}ℹ No cache file found, nothing to clear{Colors.ENDC}")
-            print(
-                f"{Colors.DIM}💡 Hint: The cache file will be created or updated after a successful sync run without --dry-run{Colors.ENDC}"
+            _print_hint(
+                "💡 Hint: The cache file will be created or updated after a successful sync run without --dry-run"
             )
         _disk_cache.clear()
         exit(0)
@@ -2929,8 +2926,8 @@ def main() -> None:
     if not args.dry_run and sys.stdin.isatty():
         if not profile_ids:
             print(f"{Colors.CYAN}ℹ Profile ID is missing.{Colors.ENDC}")
-            print(
-                f"{Colors.DIM}  You can find this in the URL of your profile in the Control D Dashboard (or just paste the URL).{Colors.ENDC}"
+            _print_hint(
+                "  You can find this in the URL of your profile in the Control D Dashboard (or just paste the URL)."
             )
 
             def validate_profile_input(value: str) -> bool:
@@ -2951,8 +2948,8 @@ def main() -> None:
 
         if not TOKEN:
             print(f"{Colors.CYAN}ℹ API Token is missing.{Colors.ENDC}")
-            print(
-                f"{Colors.DIM}  You can generate one at: https://controld.com/account/manage-account{Colors.ENDC}"
+            _print_hint(
+                "  You can generate one at: https://controld.com/account/manage-account"
             )
 
             t_input = get_password(

--- a/tests/test_ux.py
+++ b/tests/test_ux.py
@@ -460,20 +460,46 @@ class TestGetValidatedInput:
         assert f"\033[2m{main.EMPTY_INPUT_HINT}\033[0m" in captured.out
         assert f"\033[2m{main.INVALID_INPUT_HINT}\033[0m" in captured.out
 
+def test_print_hint_helper_usage(monkeypatch, capsys):
+    """Verify that _print_hint appropriately styles text and retains emojis."""
+
+    # Test NO_COLOR (False)
+    monkeypatch.setattr(main, "USE_COLORS", False)
+    main._print_hint("💡 Hint: Just a test")
+    captured = capsys.readouterr()
+    assert "\033[2m" not in captured.out
+    assert "💡 Hint: Just a test" in captured.out
+
+    # Test with colors (True)
+    monkeypatch.setattr(main, "USE_COLORS", True)
+    # Mock Colors.DIM
+    monkeypatch.setattr(main.Colors, "DIM", "\033[2m")
+    monkeypatch.setattr(main.Colors, "ENDC", "\033[0m")
+
+    main._print_hint("💡 Hint: Just a test")
+    captured = capsys.readouterr()
+    assert f"\033[2m💡 Hint: Just a test\033[0m" in captured.out
+
+
 def test_print_plan_details_retains_emojis_in_no_color(monkeypatch, capsys):
     """
     Test that print_plan_details correctly retains semantic emojis in
     the action_text when USE_COLORS is False.
     """
     monkeypatch.setattr(main, "USE_COLORS", False)
-    plan_entry = {
-        "profile_id": "test",
-        "folders": [
+
+    from typing import cast
+    from main import PlanEntry, PlanFolderEntry, PlanRuleGroup
+
+    # Create the PlanEntry correctly so it matches the TypedDict type signature
+    plan_entry = cast(PlanEntry, {
+        "profile": "test",
+        "folders": cast(list[PlanFolderEntry], [
             {"name": "Folder 1", "rules": 10, "action": 0},
-            {"name": "Folder 2", "rules": 20, "rule_groups": [{"action": 1}, {"action": 1}]},
-            {"name": "Folder 3", "rules": 30, "rule_groups": [{"action": 0}, {"action": 1}]},
-        ]
-    }
+            {"name": "Folder 2", "rules": 20, "rule_groups": cast(list[PlanRuleGroup], [{"rules": 0, "action": 1, "status": 1}, {"rules": 0, "action": 1, "status": 1}])},
+            {"name": "Folder 3", "rules": 30, "rule_groups": cast(list[PlanRuleGroup], [{"rules": 0, "action": 0, "status": 1}, {"rules": 0, "action": 1, "status": 1}])},
+        ])
+    })
     main.print_plan_details(plan_entry)
     captured = capsys.readouterr()
 

--- a/tests/test_ux.py
+++ b/tests/test_ux.py
@@ -478,7 +478,7 @@ def test_print_hint_helper_usage(monkeypatch, capsys):
 
     main._print_hint("💡 Hint: Just a test")
     captured = capsys.readouterr()
-    assert f"\033[2m💡 Hint: Just a test\033[0m" in captured.out
+    assert "\033[2m💡 Hint: Just a test\033[0m" in captured.out
 
 
 def test_print_plan_details_retains_emojis_in_no_color(monkeypatch, capsys):


### PR DESCRIPTION
**What:** Refactored direct `print` statements in `main.py` to use the custom `_print_hint` helper function. Also added a dedicated test in `tests/test_ux.py` to ensure `_print_hint` appropriately styles the text based on the `USE_COLORS` setting without losing semantic emojis.
**Why:** The codebase has a custom `_print_hint(hint: str)` function designed to handle coloring and fallback of hints securely, but it was not consistently used for many other hints such as those related to "No folders to sync", cache clearing, missing Profile ID and missing API Token. This change simplifies the logic (removes `if USE_COLORS:` branching at the call sites) and aligns with the UX best practices logged in `.jules/palette.md` to ensure emojis are preserved as uncolored text for fallback modes while keeping the CLI pretty when allowed.
**Before/After:** No functional changes. The output now consistently preserves emojis in `NO_COLOR` mode for several hints.
**Accessibility:** Improved fallback text mode rendering by ensuring semantic emojis are not stripped out, maintaining context and scannability.

---
*PR created automatically by Jules for task [9985298205871170489](https://jules.google.com/task/9985298205871170489) started by @abhimehro*