### PR TITLE
🎨 Palette: Add helpful hint for empty sync results

### DIFF
--- a/main.py
+++ b/main.py
@@ -2709,6 +2709,8 @@ def print_summary_table(
         print(
             f"{sep}\n{'TOTAL':<{w[0]}} | {t_f:>{w[1]}} | {t_r:>{w[2]},} | {t_d:>{w[3] - 1}.1f}s | {t_status:<{w[4]}}\n{sep}\n"
         )
+        if t_f == 0:
+            print("  💡 Hint: Add folder URLs using --folder-url or in your config.yaml\n")
         return
 
     # Unicode Table
@@ -2741,6 +2743,9 @@ def print_summary_table(
         f"{print_line('├', '┼', '┤', w)}\n{print_row(['TOTAL', str(t_f), f'{t_r:,}', f'{t_d:.1f}s', f'{t_col}{t_status}{Colors.ENDC}'], w)}"
     )
     print(f"{print_line('└', '┴', '┘', w)}\n")
+
+    if t_f == 0:
+        print(f"  {Colors.DIM}💡 Hint: Add folder URLs using --folder-url or in your config.yaml{Colors.ENDC}\n")
 
 
 def print_success_message(profile_ids: list[str]) -> None:

--- a/tests/test_ux.py
+++ b/tests/test_ux.py
@@ -2,6 +2,8 @@ import os
 import sys
 from unittest.mock import MagicMock
 
+import pytest
+
 import main
 
 
@@ -482,30 +484,10 @@ def test_print_plan_details_retains_emojis_in_no_color(monkeypatch, capsys):
     assert "✅ Allow" in captured.out
     assert "⚠️  Mixed" in captured.out
 
-def test_print_summary_table_empty_state_hint_unicode(monkeypatch, capsys):
-    """Test that a helpful hint is printed when total folders is 0 (Unicode mode)."""
-    monkeypatch.setattr(main, "USE_COLORS", True)
-    from main import SyncResult
-
-    sync_results = [
-        SyncResult(
-            profile="Profile_Empty",
-            folders=0,
-            rules=0,
-            duration=0.5,
-            status_label="ok",
-            success=True,
-        )
-    ]
-    main.print_summary_table(
-        sync_results=sync_results, success_count=1, total=1, dry_run=False
-    )
-    captured = capsys.readouterr()
-    assert "Hint: Add folder URLs using --folder-url or in your config.yaml" in captured.out
-
-def test_print_summary_table_empty_state_hint_ascii(monkeypatch, capsys):
-    """Test that a helpful hint is printed when total folders is 0 (ASCII mode)."""
-    monkeypatch.setattr(main, "USE_COLORS", False)
+@pytest.mark.parametrize("use_colors", [True, False])
+def test_print_summary_table_empty_state_hint(monkeypatch, capsys, use_colors: bool):
+    """Test that a helpful hint is printed when total folders is 0."""
+    monkeypatch.setattr(main, "USE_COLORS", use_colors)
     from main import SyncResult
 
     sync_results = [

--- a/tests/test_ux.py
+++ b/tests/test_ux.py
@@ -466,14 +466,14 @@ def test_print_plan_details_retains_emojis_in_no_color(monkeypatch, capsys):
     the action_text when USE_COLORS is False.
     """
     monkeypatch.setattr(main, "USE_COLORS", False)
-    plan_entry = {
-        "profile_id": "test",
-        "folders": [
-            {"name": "Folder 1", "rules": 10, "action": 0},
-            {"name": "Folder 2", "rules": 20, "rule_groups": [{"action": 1}, {"action": 1}]},
-            {"name": "Folder 3", "rules": 30, "rule_groups": [{"action": 0}, {"action": 1}]},
+    plan_entry = main.PlanEntry(
+        profile="test",
+        folders=[
+            main.PlanFolderEntry(name="Folder 1", rules=10, action=0),
+            main.PlanFolderEntry(name="Folder 2", rules=20, rule_groups=[main.PlanRuleGroup(rules=0, action=1, status=1), main.PlanRuleGroup(rules=0, action=1, status=1)]),
+            main.PlanFolderEntry(name="Folder 3", rules=30, rule_groups=[main.PlanRuleGroup(rules=0, action=0, status=1), main.PlanRuleGroup(rules=0, action=1, status=1)]),
         ]
-    }
+    )
     main.print_plan_details(plan_entry)
     captured = capsys.readouterr()
 
@@ -481,3 +481,45 @@ def test_print_plan_details_retains_emojis_in_no_color(monkeypatch, capsys):
     assert "⛔ Block" in captured.out
     assert "✅ Allow" in captured.out
     assert "⚠️  Mixed" in captured.out
+
+def test_print_summary_table_empty_state_hint_unicode(monkeypatch, capsys):
+    """Test that a helpful hint is printed when total folders is 0 (Unicode mode)."""
+    monkeypatch.setattr(main, "USE_COLORS", True)
+    from main import SyncResult
+
+    sync_results = [
+        SyncResult(
+            profile="Profile_Empty",
+            folders=0,
+            rules=0,
+            duration=0.5,
+            status_label="ok",
+            success=True,
+        )
+    ]
+    main.print_summary_table(
+        sync_results=sync_results, success_count=1, total=1, dry_run=False
+    )
+    captured = capsys.readouterr()
+    assert "Hint: Add folder URLs using --folder-url or in your config.yaml" in captured.out
+
+def test_print_summary_table_empty_state_hint_ascii(monkeypatch, capsys):
+    """Test that a helpful hint is printed when total folders is 0 (ASCII mode)."""
+    monkeypatch.setattr(main, "USE_COLORS", False)
+    from main import SyncResult
+
+    sync_results = [
+        SyncResult(
+            profile="Profile_Empty",
+            folders=0,
+            rules=0,
+            duration=0.5,
+            status_label="ok",
+            success=True,
+        )
+    ]
+    main.print_summary_table(
+        sync_results=sync_results, success_count=1, total=1, dry_run=False
+    )
+    captured = capsys.readouterr()
+    assert "Hint: Add folder URLs using --folder-url or in your config.yaml" in captured.out


### PR DESCRIPTION
**💡 What:** Added a helpful hint (`💡 Hint: Add folder URLs using --folder-url or in your config.yaml`) to the summary table when `sync_results` yields no folders.
**🎯 Why:** To provide clear, actionable guidance to users when a sync run is empty, rather than a silent failure state.
**📸 Before/After:** N/A (CLI text addition)
**♿ Accessibility:** Improves screen reader and CLI readability by eliminating confusing silent states.

---
*PR created automatically by Jules for task [3115049896167387819](https://jules.google.com/task/3115049896167387819) started by @abhimehro*