### PR TITLE
🔒 fix(security): Predictable temporary file name for cache

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -29,6 +29,7 @@ import json
 import logging
 import os
 import platform
+import tempfile
 from pathlib import Path
 from collections.abc import Callable
 from typing import Any
@@ -207,24 +208,27 @@ def save_disk_cache() -> None:
             cache_dir.chmod(0o700)
 
         cache_file = cache_dir / "blocklists.json"
-        temp_file = cache_file.with_suffix(".tmp")
 
-        # Security: use os.open so the file is created with 0o600 from the
-        # start, avoiding a TOCTOU race where a world-readable file exists
-        # briefly before a subsequent chmod.
-        # Use O_EXCL to prevent symlink attacks on predictable temporary file names.
+        # Security: use tempfile.mkstemp so a unique temporary file is created
+        # with 0o600 permissions from the start.  This prevents symlink
+        # attacks and ensures other OS users cannot read the cached data.
+        fd, temp_path = tempfile.mkstemp(dir=cache_dir, prefix="blocklists.", suffix=".tmp")
+        temp_file = Path(temp_path)
+
         try:
-            fd = os.open(temp_file, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
-        except FileExistsError:
-            # If the temp file exists from a previous aborted run, unlink and retry.
-            temp_file.unlink()
-            fd = os.open(temp_file, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(_disk_cache, f, indent=2)
 
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            json.dump(_disk_cache, f, indent=2)
-
-        # POSIX guarantees rename is atomic.
-        temp_file.replace(cache_file)
+            # POSIX guarantees rename is atomic.
+            temp_file.replace(cache_file)
+        finally:
+            # If rename failed (e.g., crash mid-dump), ensure the temp file
+            # is cleaned up so we don't leak temporary files on disk.
+            if temp_file.exists():
+                try:
+                    temp_file.unlink()
+                except Exception:
+                    pass
 
         if log.isEnabledFor(logging.DEBUG):
             log.debug(f"Saved {len(_disk_cache):,} entries to disk cache")

--- a/tests/test_disk_cache.py
+++ b/tests/test_disk_cache.py
@@ -193,16 +193,29 @@ class TestDiskCache(unittest.TestCase):
             "last_validated": 1234567890.0,
         }
 
+        # Use a real file instead of just a path so we can check if it exists
+        # during save_disk_cache execution.
         with patch("cache.get_cache_dir", return_value=cache_dir):
-            main.save_disk_cache()
+            # We want to verify that a temp file with prefix "blocklists." is used.
+            # Since mkstemp is used, we'll patch it to capture what it's called with.
+            import tempfile
+            original_mkstemp = tempfile.mkstemp
 
-        # Verify temp file is gone (was renamed)
-        temp_file = cache_dir / "blocklists.tmp"
-        self.assertFalse(temp_file.exists())
+            def mock_mkstemp(*args, **kwargs):
+                self.assertEqual(kwargs.get("prefix"), "blocklists.")
+                self.assertEqual(kwargs.get("suffix"), ".tmp")
+                return original_mkstemp(*args, **kwargs)
+
+            with patch("tempfile.mkstemp", side_effect=mock_mkstemp):
+                main.save_disk_cache()
 
         # Verify final file exists
         cache_file = cache_dir / "blocklists.json"
         self.assertTrue(cache_file.exists())
+
+        # Verify no blocklists.*.tmp files are left behind
+        temp_files = list(cache_dir.glob("blocklists.*.tmp"))
+        self.assertEqual(len(temp_files), 0, f"Found leaked temp files: {temp_files}")
 
     def test_cache_stats_tracking(self):
         """Test that cache statistics are tracked correctly."""
@@ -498,27 +511,3 @@ class TestDiskCache(unittest.TestCase):
 if __name__ == "__main__":
     unittest.main()
 
-    def test_save_disk_cache_temp_file_symlink(self):
-        """Test that O_EXCL prevents overwriting an existing symlink."""
-        cache_dir = Path(self.temp_dir)
-        cache_file = cache_dir / "blocklists.json"
-        temp_file = cache_dir / "blocklists.json.tmp"
-
-        # Pre-create a symlink at the temporary file location
-        if os.name != "nt":
-            target = cache_dir / "target_secret"
-            target.write_text("safe")
-            os.symlink("target_secret", temp_file)
-
-        # Add some data to the cache
-        main._disk_cache["test_url"] = {"data": "test_data"}
-
-        with patch("cache.get_cache_dir", return_value=cache_dir):
-            main.save_disk_cache()
-
-        # The cache should be saved successfully
-        self.assertTrue(cache_file.exists())
-
-        # If symlinks are supported, verify the target was NOT overwritten
-        if os.name != "nt":
-            self.assertEqual(target.read_text(), "safe")


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was the use of a predictable temporary filename (`blocklists.tmp`) during the cache saving process.

⚠️ **Risk:** A predictable filename could allow a local attacker to perform symlink attacks or cause a denial-of-service by pre-creating the temporary file in a shared environment.

🛡️ **Solution:** Switched to `tempfile.mkstemp` to generate unique, unpredictable temporary filenames with restrictive (0o600) permissions. Added a `finally` block to ensure cleanup of temporary files if the save or atomic rename fails. Updated the test suite to verify the new behavior and removed obsolete tests that relied on the predictable path.

---
*PR created automatically by Jules for task [1080108122848046577](https://jules.google.com/task/1080108122848046577) started by @abhimehro*