### PR TITLE
🧪 Add tests for _clean_env_kv

### DIFF
--- a/tests/test_clean_env_kv.py
+++ b/tests/test_clean_env_kv.py
@@ -2,15 +2,20 @@ import unittest
 import sys
 from unittest.mock import MagicMock
 
-# Mock dependencies that are missing in the environment
-sys.modules["httpx"] = MagicMock()
-sys.modules["dotenv"] = MagicMock()
-sys.modules["yaml"] = MagicMock()
-sys.modules["cache"] = MagicMock()
-sys.modules["api_client"] = MagicMock()
+# Environment-Safe Testing: main.py performs top-level imports of httpx, yaml, etc.
+# We ONLY mock these if they are missing from the environment to avoid interfering
+# with other tests in a full environment (like CI) that use spec=httpx.Response.
+def _maybe_mock(name):
+    if name not in sys.modules:
+        try:
+            __import__(name)
+        except ImportError:
+            sys.modules[name] = MagicMock()
 
-# Now we can import main
-import main
+for dep in ["httpx", "dotenv", "yaml", "cache", "api_client"]:
+    _maybe_mock(dep)
+
+import main  # noqa: E402
 
 class TestCleanEnvKV(unittest.TestCase):
     def test_clean_env_kv_none(self):

--- a/tests/test_clean_env_kv.py
+++ b/tests/test_clean_env_kv.py
@@ -1,0 +1,49 @@
+import unittest
+import sys
+from unittest.mock import MagicMock
+
+# Mock dependencies that are missing in the environment
+sys.modules["httpx"] = MagicMock()
+sys.modules["dotenv"] = MagicMock()
+sys.modules["yaml"] = MagicMock()
+sys.modules["cache"] = MagicMock()
+sys.modules["api_client"] = MagicMock()
+
+# Now we can import main
+import main
+
+class TestCleanEnvKV(unittest.TestCase):
+    def test_clean_env_kv_none(self):
+        self.assertIsNone(main._clean_env_kv(None, "TOKEN"))
+
+    def test_clean_env_kv_empty(self):
+        self.assertEqual(main._clean_env_kv("", "TOKEN"), "")
+
+    def test_clean_env_kv_whitespace_only(self):
+        self.assertEqual(main._clean_env_kv("   ", "TOKEN"), "")
+
+    def test_clean_env_kv_raw_value(self):
+        self.assertEqual(main._clean_env_kv("my-token-123", "TOKEN"), "my-token-123")
+
+    def test_clean_env_kv_key_value_simple(self):
+        self.assertEqual(main._clean_env_kv("TOKEN=my-token-123", "TOKEN"), "my-token-123")
+
+    def test_clean_env_kv_key_value_with_spaces(self):
+        self.assertEqual(main._clean_env_kv("TOKEN = my-token-123", "TOKEN"), "my-token-123")
+        self.assertEqual(main._clean_env_kv("  TOKEN  =  my-token-123  ", "TOKEN"), "my-token-123")
+
+    def test_clean_env_kv_mismatched_key(self):
+        # Should return the value as-is (stripped) if key doesn't match
+        self.assertEqual(main._clean_env_kv("OTHER=value", "TOKEN"), "OTHER=value")
+
+    def test_clean_env_kv_no_value_after_equals(self):
+        # If no value follows the equals sign, regex (.+) fails to match
+        self.assertEqual(main._clean_env_kv("TOKEN=", "TOKEN"), "TOKEN=")
+        self.assertEqual(main._clean_env_kv("TOKEN= ", "TOKEN"), "TOKEN=")
+
+    def test_clean_env_kv_profile_id(self):
+        self.assertEqual(main._clean_env_kv("PROFILE=p12345", "PROFILE"), "p12345")
+        self.assertEqual(main._clean_env_kv("p12345", "PROFILE"), "p12345")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implemented a new test file `tests/test_clean_env_kv.py` to verify the environment variable parsing logic in `main._clean_env_kv`. The tests handle various input formats (raw values vs KEY=value) and edge cases. Mocking is used to allow execution in environments where production dependencies are not yet installed.

---
*PR created automatically by Jules for task [321444385832091811](https://jules.google.com/task/321444385832091811) started by @abhimehro*