### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF bypass via reserved IPs

### DIFF
--- a/main.py
+++ b/main.py
@@ -1097,6 +1097,8 @@ def _is_safe_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
         return False
     if ip.is_link_local:
         return False
+    if getattr(ip, "is_reserved", False):
+        return False
     if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped:
         return _is_safe_ip(ip.ipv4_mapped)
     if isinstance(ip, ipaddress.IPv4Address) and ip in _CGNAT_NETWORK:

--- a/tests/test_ssrf_enhanced.py
+++ b/tests/test_ssrf_enhanced.py
@@ -54,6 +54,20 @@ class TestSSRFEnhanced(unittest.TestCase):
             result = main.validate_folder_url(url)
             self.assertFalse(result, "Should block domain resolving to 0.0.0.0")
 
+    def test_domain_resolving_to_reserved_ip(self):
+        """
+        Test that a domain resolving to a reserved IP (e.g., 240.0.0.1) is blocked.
+        """
+        with patch("socket.getaddrinfo") as mock_getaddrinfo:
+            # Simulate resolving to 240.0.0.1 (Class E reserved)
+            mock_getaddrinfo.return_value = [
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("240.0.0.1", 443))
+            ]
+
+            url = "https://reserved.example.com/config.json"
+            result = main.validate_folder_url(url)
+            self.assertFalse(result, "Should block domain resolving to reserved IP")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: SSRF via reserved IPs missing check
🎯 Impact: Potential internal scanning
🔧 Fix: Add `is_reserved` check
✅ Verification: Added tests and run full `pytest` suite

---
*PR created automatically by Jules for task [11037329883217029781](https://jules.google.com/task/11037329883217029781) started by @abhimehro*