### PR TITLE
🎨 Palette: Make live sync confirmation fail-secure

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -50,3 +50,7 @@
 ## 2024-04-15 - Semantic Emojis in No-Color Fallbacks
 **Learning:** When stripping ANSI colors for fallback modes (e.g., `NO_COLOR=1` or non-TTY environments), it's a common mistake to accidentally strip semantic emojis along with the color formatting. Emojis provide vital scannability and context that users rely on when color cues are absent.
 **Action:** Always ensure that `if USE_COLORS` else blocks preserve emojis in the uncolored strings. Never treat emojis as part of the "color decoration" to be discarded.
+## 2025-03-31 - [Fail-Open CLI Prompts]
+
+**Learning:** Implementing a "fail-open" pattern in interactive CLI prompts for destructive actions (where any unrecognized input is treated as a confirmation) is dangerous and can lead to unintended execution if the user makes a typo or misunderstands the prompt.
+**Action:** Interactive confirmation prompts for destructive actions must be "fail-secure". They should explicitly validate for expected confirmation strings (e.g., "", "y", "yes") and expected cancellation strings (e.g., "n", "quit"). Any unrecognized input should be explicitly rejected with a clear error message, and the prompt should be repeated until valid input is received.

--- a/main.py
+++ b/main.py
@@ -2644,16 +2644,26 @@ def prompt_for_interactive_restart(profile_ids: list[str]) -> None:
         else:
             prompt = "\n🚀 Ready to launch? Press [Enter] to run now (or type 'n' / Ctrl+C to cancel)... "
 
-        # Flush stdout (and stderr) so the prompt is visible even if output is buffered or redirected
-        sys.stdout.flush()
-        sys.stderr.flush()
-        user_response = input(prompt).strip().lower()
-        if user_response in ("n", "no", "q", "quit", "exit", "cancel"):
+        while True:
+            # Flush stdout (and stderr) so the prompt is visible even if output is buffered or redirected
+            sys.stdout.flush()
+            sys.stderr.flush()
+            user_response = input(prompt).strip().lower()
+
+            if user_response in ("n", "no", "q", "quit", "exit", "cancel"):
+                if USE_COLORS:
+                    print(f"\n{Colors.WARNING}⚠️  Cancelled.{Colors.ENDC}")
+                else:
+                    print("\n⚠️  Cancelled.")
+                return
+
+            if user_response in ("", "y", "yes"):
+                break
+
             if USE_COLORS:
-                print(f"\n{Colors.WARNING}⚠️  Cancelled.{Colors.ENDC}")
+                print(f"{Colors.FAIL}❌ Unrecognized input. Please press [Enter] to confirm, or type 'n' to cancel.{Colors.ENDC}")
             else:
-                print("\n⚠️  Cancelled.")
-            return
+                print("❌ Unrecognized input. Please press [Enter] to confirm, or type 'n' to cancel.")
 
         # Prepare environment for the new process
         # Pass the current token to avoid re-prompting if it was entered interactively

--- a/tests/test_ux.py
+++ b/tests/test_ux.py
@@ -404,6 +404,54 @@ class TestPromptForInteractiveRestart:
             captured = capsys.readouterr()
             assert "Cancelled" in captured.out
 
+    def test_handles_unrecognized_input_then_confirms(self, monkeypatch, capsys):
+        """Should reject invalid input, then accept valid confirmation."""
+        monkeypatch.setattr(sys, "stdin", _DummyStdin(is_tty=True))
+
+        # First give invalid input, then give empty string (Enter)
+        inputs = iter(["invalid_input", ""])
+
+        def mock_input(_):
+            return next(inputs)
+
+        monkeypatch.setattr("builtins.input", mock_input)
+        mock_execv = MagicMock()
+        monkeypatch.setattr(os, "execv", mock_execv)
+        monkeypatch.setattr(main, "USE_COLORS", False)
+
+        # To avoid the test hanging, we also need to mock os.environ
+        monkeypatch.setattr(os, "environ", {})
+        monkeypatch.setattr(sys, "executable", "python")
+        monkeypatch.setattr(sys, "argv", ["main.py", "--dry-run"])
+
+        main.prompt_for_interactive_restart(["123"])
+
+        captured = capsys.readouterr()
+        assert "Unrecognized input" in captured.out
+        mock_execv.assert_called_once()
+
+    def test_handles_unrecognized_input_then_cancels(self, monkeypatch, capsys):
+        """Should reject invalid input, then accept valid cancellation."""
+        monkeypatch.setattr(sys, "stdin", _DummyStdin(is_tty=True))
+
+        # First give invalid input, then give cancel command
+        inputs = iter(["invalid_input", "n"])
+
+        def mock_input(_):
+            return next(inputs)
+
+        monkeypatch.setattr("builtins.input", mock_input)
+        mock_execv = MagicMock()
+        monkeypatch.setattr(os, "execv", mock_execv)
+        monkeypatch.setattr(main, "USE_COLORS", False)
+
+        main.prompt_for_interactive_restart(["123"])
+
+        captured = capsys.readouterr()
+        assert "Unrecognized input" in captured.out
+        assert "Cancelled" in captured.out
+        mock_execv.assert_not_called()
+
 
 class TestGetValidatedInput:
     def test_get_validated_input_no_colors(self, monkeypatch, capsys):


### PR DESCRIPTION
💡 What: Refactored the `prompt_for_interactive_restart` CLI prompt to use a fail-secure `while True:` loop. Instead of continuing execution on *any* unrecognized input, it now explicitly requires an empty string, "y", or "yes" to proceed.
🎯 Why: The previous "fail-open" pattern was dangerous. If a user made a typo while trying to cancel or hit the wrong key, the prompt would treat it as a confirmation and immediately begin the destructive live sync process. This change ensures users don't accidentally execute a sync.
📸 Before/After: Before, typing "c" instead of "q" would start the sync. After, typing "c" yields an explicit error: `❌ Unrecognized input. Please press [Enter] to confirm, or type 'n' to cancel.`
♿ Accessibility: The error message restates the exact valid key commands, aiding users who may have forgotten the options or are using assistive technologies that limit their ability to easily scroll back up to the initial prompt text.

---
*PR created automatically by Jules for task [15874263225612823483](https://jules.google.com/task/15874263225612823483) started by @abhimehro*