### PR TITLE
🎨 Palette: Fail-secure interactive restart prompt

### DIFF
--- a/main.py
+++ b/main.py
@@ -2644,16 +2644,28 @@ def prompt_for_interactive_restart(profile_ids: list[str]) -> None:
         else:
             prompt = "\n🚀 Ready to launch? Press [Enter] to run now (or type 'n' / Ctrl+C to cancel)... "
 
-        # Flush stdout (and stderr) so the prompt is visible even if output is buffered or redirected
-        sys.stdout.flush()
-        sys.stderr.flush()
-        user_response = input(prompt).strip().lower()
-        if user_response in ("n", "no", "q", "quit", "exit", "cancel"):
+        while True:
+            # Flush stdout (and stderr) so the prompt is visible even if output is buffered or redirected
+            sys.stdout.flush()
+            sys.stderr.flush()
+            user_response = input(prompt).strip().lower()
+
+            if user_response in ("", "y", "yes"):
+                break
+
+            if user_response in ("n", "no", "q", "quit", "exit", "cancel"):
+                if USE_COLORS:
+                    print(f"\n{Colors.WARNING}⚠️  Cancelled.{Colors.ENDC}")
+                else:
+                    print("\n⚠️  Cancelled.")
+                return
+
             if USE_COLORS:
-                print(f"\n{Colors.WARNING}⚠️  Cancelled.{Colors.ENDC}")
+                print(f"{Colors.FAIL}❌ Unrecognized input.{Colors.ENDC}")
+                _print_hint("   💡 Hint: Please type 'y' or press Enter to continue, or 'n' to cancel.")
             else:
-                print("\n⚠️  Cancelled.")
-            return
+                print("❌ Unrecognized input.")
+                _print_hint("   💡 Hint: Please type 'y' or press Enter to continue, or 'n' to cancel.")
 
         # Prepare environment for the new process
         # Pass the current token to avoid re-prompting if it was entered interactively

--- a/main.py
+++ b/main.py
@@ -779,6 +779,23 @@ def _print_hint(hint: str) -> None:
         print(hint)
 
 
+def _print_cancellation_message() -> None:
+    """Helper to print cancellation message honoring colors."""
+    if USE_COLORS:
+        print(f"\n{Colors.WARNING}⚠️  Cancelled.{Colors.ENDC}")
+    else:
+        print("\n⚠️  Cancelled.")
+
+
+def _print_unrecognized_input_message() -> None:
+    """Helper to print unrecognized input message honoring colors."""
+    if USE_COLORS:
+        print(f"{Colors.FAIL}❌ Unrecognized input.{Colors.ENDC}")
+    else:
+        print("❌ Unrecognized input.")
+    _print_hint("   💡 Hint: Please type 'y' or press Enter to continue, or 'n' to cancel.")
+
+
 def get_validated_input(
     prompt: str,
     validator: Callable[[str], bool],
@@ -2654,18 +2671,10 @@ def prompt_for_interactive_restart(profile_ids: list[str]) -> None:
                 break
 
             if user_response in ("n", "no", "q", "quit", "exit", "cancel"):
-                if USE_COLORS:
-                    print(f"\n{Colors.WARNING}⚠️  Cancelled.{Colors.ENDC}")
-                else:
-                    print("\n⚠️  Cancelled.")
+                _print_cancellation_message()
                 return
 
-            if USE_COLORS:
-                print(f"{Colors.FAIL}❌ Unrecognized input.{Colors.ENDC}")
-                _print_hint("   💡 Hint: Please type 'y' or press Enter to continue, or 'n' to cancel.")
-            else:
-                print("❌ Unrecognized input.")
-                _print_hint("   💡 Hint: Please type 'y' or press Enter to continue, or 'n' to cancel.")
+            _print_unrecognized_input_message()
 
         # Prepare environment for the new process
         # Pass the current token to avoid re-prompting if it was entered interactively

--- a/tests/test_ux.py
+++ b/tests/test_ux.py
@@ -404,6 +404,28 @@ class TestPromptForInteractiveRestart:
             captured = capsys.readouterr()
             assert "Cancelled" in captured.out
 
+    def test_reprompts_on_unrecognized_input(self, monkeypatch, capsys):
+        """Should reprompt when input is neither affirmative nor cancellation."""
+        monkeypatch.setattr(sys, "stdin", _DummyStdin(is_tty=True))
+
+        # We will feed 'maybe', then 'invalid', then 'y'
+        inputs = iter(["maybe", "invalid", "y"])
+        def mock_input(_):
+            return next(inputs)
+
+        monkeypatch.setattr("builtins.input", mock_input)
+        mock_execv = MagicMock()
+        monkeypatch.setattr(os, "execv", mock_execv)
+
+        main.prompt_for_interactive_restart(["123"])
+
+        mock_execv.assert_called_once()
+        captured = capsys.readouterr()
+
+        # Ensure it printed the unrecognized input error twice
+        assert captured.out.count("Unrecognized input") == 2
+        assert "Hint: Please type 'y' or press Enter to continue, or 'n' to cancel." in captured.out
+
 
 class TestGetValidatedInput:
     def test_get_validated_input_no_colors(self, monkeypatch, capsys):


### PR DESCRIPTION
💡 What: Updated the `prompt_for_interactive_restart` to explicitly check for positive ("y", "yes", "") and negative ("n", "no", "q", "quit", "exit", "cancel") input. Unrecognized input now triggers a clear error message and re-prompts the user instead of defaulting to a continuation.
🎯 Why: Previously, any string that wasn't a negative keyword would cause the script to execute the live run. This fail-secure approach ensures that the user doesn't accidentally run the tool when typing random characters or expecting the prompt to ask again.
📸 Before/After: N/A
♿ Accessibility: Provides explicit hints on unrecognized input, helping all users understand what is required.

---
*PR created automatically by Jules for task [14101524465850462056](https://jules.google.com/task/14101524465850462056) started by @abhimehro*