### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix missing is_reserved check in IP validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The `_is_safe_ip` function lacked an explicit check for link-local IP addresses (e.g., `169.254.169.254`). This omission exposed the application to SSRF vulnerabilities targeting cloud provider metadata APIs (such as AWS IMDS, GCP Metadata, Azure Instance Metadata), which could lead to severe credential exposure.
 **Learning:** Cloud metadata services reside on non-routable link-local IP addresses that are not always covered by standard `is_private` or `is_global` properties.
 **Prevention:** Explicitly check `ip.is_link_local` alongside `is_loopback`, `is_unspecified`, and `is_private` when validating outbound destination IPs.
+
+## 2025-05-01 - Add explicit reserved IP check to prevent SSRF bypass
+**Vulnerability:** The `_is_safe_ip` function lacked an explicit check for reserved IP addresses (e.g., `240.0.0.1`). This omission exposed the application to SSRF vulnerabilities where attackers could bypass `is_private` and `is_global` checks by using reserved IP ranges.
+**Learning:** Reserved IP addresses (like the IPv4 Class E space `240.0.0.0/4`) are not always covered by standard `is_private` checks, meaning they can be evaluated as global or safe depending on the implementation.
+**Prevention:** Explicitly check `getattr(ip, "is_reserved", False)` alongside `is_loopback`, `is_link_local`, `is_unspecified`, and `is_private` when validating outbound destination IPs.

--- a/main.py
+++ b/main.py
@@ -1097,6 +1097,8 @@ def _is_safe_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
         return False
     if ip.is_link_local:
         return False
+    if getattr(ip, "is_reserved", False):
+        return False
     if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped:
         return _is_safe_ip(ip.ipv4_mapped)
     if isinstance(ip, ipaddress.IPv4Address) and ip in _CGNAT_NETWORK:

--- a/test_main.py
+++ b/test_main.py
@@ -797,6 +797,18 @@ def test_validate_folder_data_structure(monkeypatch):
     assert m.validate_folder_data(valid_rg, "url") is True
 
 
+def test_is_safe_ip_reserved():
+    import ipaddress
+    import main
+
+    # Test valid global IP
+    assert main._is_safe_ip(ipaddress.IPv4Address("8.8.8.8")) is True
+    assert main._is_safe_ip(ipaddress.IPv6Address("2001:4860:4860::8888")) is True
+
+    # Test newly added reserved IP block
+    assert main._is_safe_ip(ipaddress.IPv4Address("240.0.0.1")) is False
+
+
 def test_is_valid_profile_id_format(monkeypatch):
     m = reload_main_with_env(monkeypatch)
     # Valid IDs


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `_is_safe_ip` function in `main.py` lacked an explicit check for reserved IP addresses (like the `240.0.0.0/4` space). This omission allowed attackers to bypass standard `is_private` and `is_global` checks by supplying reserved IP ranges, exposing the application to Server-Side Request Forgery (SSRF) vulnerabilities.
🎯 Impact: Attackers could potentially access internal network resources or cloud metadata services that reside on reserved IP addresses, leading to information disclosure or further compromise.
🔧 Fix: Enhanced `_is_safe_ip` to explicitly block reserved IPs by checking `getattr(ip, "is_reserved", False)`. Added a comprehensive test case in `test_main.py` to ensure reserved IPs (e.g., `240.0.0.1`) are correctly blocked while valid global IPs are allowed. Updated the Sentinel journal with this critical learning.
✅ Verification: Run the test suite using `uv run pytest`. The new test `test_is_safe_ip_reserved` in `test_main.py` should pass, confirming that reserved IPs are blocked.

---
*PR created automatically by Jules for task [5739476314702205508](https://jules.google.com/task/5739476314702205508) started by @abhimehro*