### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing Content-Type validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** The `_is_safe_ip` function lacked an explicit check for reserved IP addresses (e.g., `240.0.0.0/4`). This omission exposed the application to potential SSRF vulnerabilities targeting these non-global, but potentially routable or internally handled IP ranges that bypass the `is_private` check.
 **Learning:** Reserved IP addresses are not always covered by standard `is_private` or `is_global` properties and must be explicitly handled. The supported Python runtime exposes `is_reserved` on IP address objects, so use it directly to avoid fail-open behavior.
 **Prevention:** Explicitly check `ip.is_reserved` alongside other non-global IP checks when validating outbound destination IPs.
+
+## 2025-05-03 - Add missing Content-Type validation in fallback HTTP request branch
+**Vulnerability:** A missing Content-Type validation check existed in the retry block of the `_gh_get` function. While the main HTTP request block checked that `Content-Type` was one of the allowed types (e.g. `application/json`), the fallback request branch (executed when the cache returns a 304 without cached data) did not. This omission allowed processing of unexpected or potentially malicious content types.
+**Learning:** Security validations must be enforced consistently across all code paths, particularly in fallback, retry, and error-handling branches. Omitting checks in less frequently traversed paths creates defense-in-depth gaps that can be exploited if an attacker can trigger the fallback behavior.
+**Prevention:** Apply identical security validation and sanitization logic to both primary and fallback code paths. Abstracting shared validation logic into dedicated helper functions can further prevent such discrepancies.

--- a/main.py
+++ b/main.py
@@ -1516,6 +1516,15 @@ def _gh_get(url: str) -> dict:
                 with _gh.stream("GET", url, headers=headers) as r_retry:
                     r_retry.raise_for_status()
 
+                    # Security: Validate Content-Type in fallback branch
+                    content_type = r_retry.headers.get("Content-Type", "").lower()
+                    allowed_types = ["application/json", "text/json", "text/plain"]
+                    if not any(t in content_type for t in allowed_types):
+                        raise ValueError(
+                            f"Invalid Content-Type from {url}: {content_type}. "
+                            f"Expected one of: {', '.join(allowed_types)}"
+                        )
+
                     # 1. Check Content-Length header if present
                     cl = r_retry.headers.get("Content-Length")
                     if cl:

--- a/main.py
+++ b/main.py
@@ -1521,7 +1521,7 @@ def _gh_get(url: str) -> dict:
                     allowed_types = ["application/json", "text/json", "text/plain"]
                     if not any(t in content_type for t in allowed_types):
                         raise ValueError(
-                            f"Invalid Content-Type from {url}: {content_type}. "
+                            f"Invalid Content-Type from {sanitize_for_log(url)}: {content_type}. "
                             f"Expected one of: {', '.join(allowed_types)}"
                         )
 

--- a/main.py
+++ b/main.py
@@ -1546,7 +1546,8 @@ def _gh_get(url: str) -> dict:
                     # 2. Stream and check actual size
                     chunks = []
                     current_size = 0
-                    for chunk in r_retry.iter_bytes():
+                    # Optimization: Use 16KB chunks to reduce loop overhead/appends for large files
+                    for chunk in r_retry.iter_bytes(chunk_size=16 * 1024):
                         current_size += len(chunk)
                         if current_size > MAX_RESPONSE_SIZE:
                             raise ValueError(

--- a/main.py
+++ b/main.py
@@ -1521,7 +1521,7 @@ def _gh_get(url: str) -> dict:
                     allowed_types = ["application/json", "text/json", "text/plain"]
                     if not any(t in content_type for t in allowed_types):
                         raise ValueError(
-                            f"Invalid Content-Type from {sanitize_for_log(url)}: {content_type}. "
+                            f"Invalid Content-Type from {url}: {content_type}. "
                             f"Expected one of: {', '.join(allowed_types)}"
                         )
 
@@ -1546,8 +1546,7 @@ def _gh_get(url: str) -> dict:
                     # 2. Stream and check actual size
                     chunks = []
                     current_size = 0
-                    # Optimization: Use 16KB chunks to reduce loop overhead/appends for large files
-                    for chunk in r_retry.iter_bytes(chunk_size=16 * 1024):
+                    for chunk in r_retry.iter_bytes():
                         current_size += len(chunk)
                         if current_size > MAX_RESPONSE_SIZE:
                             raise ValueError(


### PR DESCRIPTION
**Severity:** MEDIUM
**Vulnerability:** The HTTP retry branch inside `_gh_get` lacked Content-Type validation, which could allow the application to process unexpected or potentially malicious content types if the initial response was a 304 and the cached data was missing.
**Impact:** A malicious server could respond with an HTML or XML payload instead of JSON during a retry. Processing unexpected content types could lead to parsing vulnerabilities or downstream application errors.
**Fix:** Added the identical `Content-Type` validation logic from the primary HTTP branch to the fallback retry branch.
**Verification:** Run `uv run pytest tests/` to verify tests pass and no regressions were introduced.

---
*PR created automatically by Jules for task [4184539243305221398](https://jules.google.com/task/4184539243305221398) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/ctrld-sync/pull/763" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->