### PR TITLE
🎨 Palette: Add empty state hint in main summary table

### DIFF
--- a/main.py
+++ b/main.py
@@ -3218,6 +3218,12 @@ def main() -> None:
     # Bottom Border
     print(make_col_separator(Box.BL, Box.B, Box.BR, Box.H, col_widths))
 
+    if total_folders == 0:
+        print()  # Spacer
+        _print_hint(
+            "  💡 Hint: Add folder URLs using --folder-url or in your config.yaml"
+        )
+
     # Success Delight
     if all_success and not args.dry_run:
         print_success_message(profile_ids)


### PR DESCRIPTION
💡 **What:** Added the missing empty state hint to the bottom of the summary table output in `main()` when no folders are selected.
🎯 **Why:** The script previously failed to provide guidance on empty states (0 folders processed) after printing the summary table, leaving users confused about how to configure folders. This resolves the lack of actionable context for a common zero-configuration state.
📸 **Before/After:** Before, the terminal output ended abruptly with the summary table total row showing 0 folders. After, an explicit hint is appended underneath: `💡 Hint: Add folder URLs using --folder-url or in your config.yaml`.
♿ **Accessibility:** By providing an actionable next step in plain text, this prevents cognitive load and frustration for new users or those running automated pipelines who might not otherwise know the necessary CLI flags or config paths.

---
*PR created automatically by Jules for task [10060997268630997989](https://jules.google.com/task/10060997268630997989) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/ctrld-sync/pull/768" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->