### PR TITLE
fix(security): prevent shell injection from AI-inference output in summary.yml

### DIFF
--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -26,9 +26,9 @@ jobs:
             Body: ${{ github.event.issue.body }}
 
       - name: Comment with AI summary
-        run: |
-          gh issue comment $ISSUE_NUMBER --body '${{ steps.inference.outputs.response }}'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           RESPONSE: ${{ steps.inference.outputs.response }}
+        run: |
+          gh issue comment "$ISSUE_NUMBER" --body "$RESPONSE"


### PR DESCRIPTION
# Submitting a Pull Request

## Summary

Closes #767

Fix a HIGH-severity GitHub Actions command injection in `.github/workflows/summary.yml` that was reachable by **any** unauthenticated GitHub user opening an issue (the workflow triggers on `issues: opened`).

The `Comment with AI summary` step interpolated `steps.inference.outputs.response` directly into a single-quoted bash argument:

```yaml
run: |
  gh issue comment $ISSUE_NUMBER --body '${{ steps.inference.outputs.response }}'
```

GitHub Actions performs `${{ ... }}` substitution textually *before* bash is invoked, so any single quote (or other shell metacharacter) the AI emits closes the quoted argument and the rest is interpreted as additional shell commands. Because the AI prompt is built from the issue title/body — both fully attacker-controlled — an attacker can use a prompt-injection payload to coerce the AI response into a shell-injection payload, then use that to run arbitrary commands on the runner with `GITHUB_TOKEN` available.

This is the canonical "GitHub Actions script injection" pattern — see [GitHub Security Lab: keeping your GitHub Actions and workflows secure](https://securitylab.github.com/research/github-actions-untrusted-input/).

### What Changed and Why

- `summary.yml`: pass `steps.inference.outputs.response` via the existing (declared but previously unused) `RESPONSE` environment variable, and consume it in the `run:` block as `"$RESPONSE"`.

Bash variable expansion does **not** re-parse the value as shell code, so embedded quotes / `;` / `$()` / backticks are inert — the injection sink is closed without changing observable behaviour. The `RESPONSE` env var was already defined in the step but the `run:` block was still interpolating the GitHub-Actions expression directly; this PR makes the run block actually use the env var.

### How to test or verify

- Static check: `summary.yml` is otherwise unchanged; the `gh issue comment` invocation now uses `"$ISSUE_NUMBER"` and `"$RESPONSE"` (both env vars), with no `${{ ... }}` interpolation inside the `run:` block.
- Behavioural: the next time an issue is opened, the AI-generated summary will still be posted as the first comment (same body, same target issue), but a malicious response such as `'; rm -rf / #` will be posted as text instead of being executed.

### Branch Naming

- [x] `fix/<short-description>` for bug fixes (used `devin/<ts>-fix-summary-yml-injection` as required by the project's session-branch convention)

## Security Implications

- [x] No secrets or credentials are introduced or exposed by this change. This change *removes* a path to exfiltrating `GITHUB_TOKEN` from the runner.

## Checklist

- [x] Commit message is clear and descriptive
- [x] Diff is minimal and scoped (2 lines changed)
- [x] No tests added — the change is workflow YAML only; behaviour is unchanged on the success path
- [x] No documentation changes required
- [x] No secrets, credentials, tokens, profiles, or `.env` files included

Link to Devin session: https://app.devin.ai/sessions/409884d0fe6a4201a1d03d305df79bf4
Requested by: @abhimehro
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/ctrld-sync/pull/769" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->