### PR TITLE
🛡️ Sentinel: [HIGH] Fix log sanitization to redact authorization parameters

### DIFF
--- a/main.py
+++ b/main.py
@@ -519,7 +519,7 @@ _UNSAFE_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
 # Pre-compiled patterns for log sanitization
 _BASIC_AUTH_PATTERN = re.compile(r"://[^/@]+@")
 _SENSITIVE_PARAM_PATTERN = re.compile(
-    r"([?&#])(token|key|secret|password|auth|access_token|api_key)=[^&#\s]*",
+    r"([?&#])(token|key|secret|password|auth|authorization|access_token|api_key)=[^&#\s]*",
     flags=re.IGNORECASE,
 )
 

--- a/tests/test_log_sanitization.py
+++ b/tests/test_log_sanitization.py
@@ -106,6 +106,13 @@ class TestLogSanitization(unittest.TestCase):
         self.assertNotIn("mytoken", sanitized)
         self.assertIn("[REDACTED]", sanitized)
 
+    def test_sanitize_for_log_redacts_authorization(self):
+        """Test that authorization parameters are correctly redacted."""
+        url = "https://example.com/api?authorization=Bearer%20token123"
+        sanitized = main.sanitize_for_log(url)
+        self.assertNotIn("token123", sanitized)
+        self.assertIn("authorization=[REDACTED]", sanitized)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The log sanitization regex (`_SENSITIVE_PARAM_PATTERN`) failed to explicitly redact `authorization` parameters. While it caught `token` and `api_key`, `authorization` could be passed via query string and leaked into application logs.
🎯 Impact: Credential exposure in log files, potentially compromising user accounts or API access if logs are viewed by unauthorized personnel.
🔧 Fix: Expanded `_SENSITIVE_PARAM_PATTERN` in `main.py` to explicitly include `authorization` in the list of redacted keys.
✅ Verification: Added a new test `test_sanitize_for_log_redacts_authorization` to `tests/test_log_sanitization.py` and successfully ran the test suite (`uv run pytest`).

---
*PR created automatically by Jules for task [14814906865062264945](https://jules.google.com/task/14814906865062264945) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/ctrld-sync/pull/772" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->