### PR TITLE
🛡️ Sentinel: [MEDIUM] Add authorization parameter to log sanitization

### DIFF
--- a/main.py
+++ b/main.py
@@ -519,7 +519,7 @@ _UNSAFE_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
 # Pre-compiled patterns for log sanitization
 _BASIC_AUTH_PATTERN = re.compile(r"://[^/@]+@")
 _SENSITIVE_PARAM_PATTERN = re.compile(
-    r"([?&#])(token|key|secret|password|auth|access_token|api_key)=[^&#\s]*",
+    r"([?&#])(token|key|secret|password|auth|access_token|api_key|authorization)=[^&#\s]*",
     flags=re.IGNORECASE,
 )
 

--- a/tests/test_log_sanitization.py
+++ b/tests/test_log_sanitization.py
@@ -106,6 +106,13 @@ class TestLogSanitization(unittest.TestCase):
         self.assertNotIn("mytoken", sanitized)
         self.assertIn("[REDACTED]", sanitized)
 
+    def test_sanitize_for_log_redacts_authorization_param(self):
+        """Test that sanitize_for_log redacts the authorization query parameter."""
+        url = "https://example.com/api?authorization=Bearer%20mytoken"
+        sanitized = main.sanitize_for_log(url)
+        self.assertNotIn("Bearer%20mytoken", sanitized)
+        self.assertIn("authorization=[REDACTED]", sanitized)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Severity:** MEDIUM
**Vulnerability:** The `_SENSITIVE_PARAM_PATTERN` in `main.py` did not explicitly include the `authorization` parameter. This could lead to the exposure of authentication tokens (e.g., Bearer tokens) passed via URL query parameters or fragments if an error occurred or the URL was otherwise logged.
**Impact:** Leakage of `authorization` tokens in logs could allow an attacker with log access to impersonate users or bypass authentication controls.
**Fix:** Updated the pre-compiled regular expression `_SENSITIVE_PARAM_PATTERN` to explicitly include `authorization` in the list of redacted parameters. Also added a corresponding unit test to verify the redaction.
**Verification:** Added `test_sanitize_for_log_redacts_authorization_param` to `tests/test_log_sanitization.py`. Verified that the test passes and the pattern successfully redacts `authorization` values. Run `uv run pytest tests/` to confirm all tests pass.

---
*PR created automatically by Jules for task [12438108016152085206](https://jules.google.com/task/12438108016152085206) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/ctrld-sync/pull/774" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->