### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix Authorization Log Leakage

### DIFF
--- a/main.py
+++ b/main.py
@@ -519,7 +519,7 @@ _UNSAFE_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
 # Pre-compiled patterns for log sanitization
 _BASIC_AUTH_PATTERN = re.compile(r"://[^/@]+@")
 _SENSITIVE_PARAM_PATTERN = re.compile(
-    r"([?&#])(token|key|secret|password|auth|access_token|api_key)=[^&#\s]*",
+    r"([?&#])(token|key|secret|password|auth|access_token|api_key|authorization)=[^&#\s]*",
     flags=re.IGNORECASE,
 )
 

--- a/tests/test_log_sanitization.py
+++ b/tests/test_log_sanitization.py
@@ -85,10 +85,12 @@ class TestLogSanitization(unittest.TestCase):
 
     def test_sanitize_for_log_redacts_query_params(self):
         """Test that sanitize_for_log redacts sensitive query parameters."""
-        url = "https://example.com/api?secret=mysecretkey"
+        url = "https://example.com/api?secret=mysecretkey&authorization=Bearer123"
         sanitized = main.sanitize_for_log(url)
         self.assertNotIn("mysecretkey", sanitized)
+        self.assertNotIn("Bearer123", sanitized)
         self.assertIn("secret=[REDACTED]", sanitized)
+        self.assertIn("authorization=[REDACTED]", sanitized)
 
     def test_sanitize_for_log_redacts_multiple_params(self):
         """Test redaction of multiple sensitive params while preserving safe ones."""


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `authorization` was not redacted in `_SENSITIVE_PARAM_PATTERN`.
🎯 Impact: Credential leakage in logs via query parameters.
🔧 Fix: Added `authorization` to the regex pattern.
✅ Verification: Added tests to ensure `authorization` is properly redacted.

---
*PR created automatically by Jules for task [16522109757379176870](https://jules.google.com/task/16522109757379176870) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/ctrld-sync/pull/775" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches security-related log sanitization by expanding the sensitive-parameter redaction regex; risk is limited but mistakes could still allow credential leakage or over-redact URLs in logs.
> 
> **Overview**
> Extends `sanitize_for_log`’s sensitive query-parameter redaction to also mask `authorization=...` values so bearer/credential-like data isn’t leaked into logs.
> 
> Updates the log-sanitization test to cover redaction of both `secret` and `authorization` parameters in the same URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0693ac7dd760dc86e6cf99cd895c6958338b894. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->