### PR TITLE
🎨 Palette: Apply pluralize helper to log messages

### DIFF
--- a/main.py
+++ b/main.py
@@ -1989,7 +1989,7 @@ def warm_up_cache(urls: Sequence[str]) -> None:
 
     total = len(urls_to_process)
     if not USE_COLORS:
-        log.info(f"⏳ Warming up cache for {total:,} URLs...")
+        log.info(f"⏳ Warming up cache for {total:,} {pluralize(total, 'URL')}...")
 
     # OPTIMIZATION: Combine validation (DNS) and fetching (HTTP) in one task
     # to allow validation latency to be parallelized.
@@ -2628,7 +2628,7 @@ def sync_profile(
                         )
 
         log.info(
-            f"Sync complete: {success_count}/{len(folder_data_list)} folders processed successfully"
+            f"Sync complete: {success_count}/{len(folder_data_list)} {pluralize(len(folder_data_list), 'folder')} processed successfully"
         )
         return success_count == len(folder_data_list)
 


### PR DESCRIPTION
## 💡 What
Applied the existing `pluralize` helper function to dynamically output grammatically correct log messages (e.g., '1 URL' vs '2 URLs', '1 folder' vs '2 folders').

## 🎯 Why
Correctly pluralizing output nouns based on count enhances readability and improves the CLI micro-UX by avoiding awkward phrases like '1 URLs'.

## 📸 Before/After
**Before:**
`Warming up cache for 1 URLs...`
`All profiles processed: 1/1 successful`

**After:**
`Warming up cache for 1 URL...`
`All profiles processed: 1/1 successful` (and `1 folder` instead of `1 folders` in sync logs).

## ♿ Accessibility
Cleaner, grammatically correct console logs are slightly easier for screen readers to process naturally.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/ctrld-sync/pull/782" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->