### PR TITLE
🛡️ Sentinel: [security improvement] Sanitize Content-Type in ValueError messages

### DIFF
--- a/main.py
+++ b/main.py
@@ -1528,7 +1528,7 @@ def _gh_get(url: str) -> dict:
                     allowed_types = ["application/json", "text/json", "text/plain"]
                     if not any(t in content_type for t in allowed_types):
                         raise ValueError(
-                            f"Invalid Content-Type from {url}: {content_type}. "
+                            f"Invalid Content-Type from {sanitize_for_log(url)}: {sanitize_for_log(content_type)}. "
                             f"Expected one of: {', '.join(allowed_types)}"
                         )
 
@@ -1594,7 +1594,7 @@ def _gh_get(url: str) -> dict:
             allowed_types = ["application/json", "text/json", "text/plain"]
             if not any(t in content_type for t in allowed_types):
                 raise ValueError(
-                    f"Invalid Content-Type from {sanitize_for_log(url)}: {content_type}. "
+                    f"Invalid Content-Type from {sanitize_for_log(url)}: {sanitize_for_log(content_type)}. "
                     f"Expected one of: {', '.join(allowed_types)}"
                 )
 


### PR DESCRIPTION
**Severity:** Medium
**Vulnerability:** External input (`content_type`) was passed into `ValueError` string without sanitization. Since exceptions are commonly logged, including raw, potentially attacker-controlled HTTP header data could lead to Log Injection attacks.
**Impact:** Attackers could inject arbitrary log entries or control characters, confusing monitoring systems or hiding traces of malicious activity.
**Fix:** Used the existing `sanitize_for_log()` function to sanitize the `content_type` variables before embedding them in the exception message.
**Verification:** Verified using `uv run pytest tests/test_content_type.py` and the full test suite.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/ctrld-sync/pull/783" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->