### PR TITLE
chore: auto-format fix_env.py

### DIFF
--- a/fix_env.py
+++ b/fix_env.py
@@ -99,7 +99,12 @@ def fix_env():
         # tempfile.NamedTemporaryFile securely creates a unique file with O_CREAT | O_EXCL and 0o600 permissions
         # We specify dir="." to keep it on the same filesystem as .env for atomic os.replace
         with tempfile.NamedTemporaryFile(
-            mode="w", delete=False, prefix=".env.", suffix=".tmp", dir=".", encoding="utf-8"
+            mode="w",
+            delete=False,
+            prefix=".env.",
+            suffix=".tmp",
+            dir=".",
+            encoding="utf-8",
         ) as f:
             temp_file = f.name
             f.write(new_content)


### PR DESCRIPTION
Auto-formats `fix_env.py` using `ruff`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/ctrld-sync/pull/785" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->