### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix log injection vulnerability in Content-Type fallback branch error message

### DIFF
--- a/main.py
+++ b/main.py
@@ -1528,7 +1528,7 @@ def _gh_get(url: str) -> dict:
                     allowed_types = ["application/json", "text/json", "text/plain"]
                     if not any(t in content_type for t in allowed_types):
                         raise ValueError(
-                            f"Invalid Content-Type from {url}: {content_type}. "
+                            f"Invalid Content-Type from {sanitize_for_log(url)}: {content_type}. "
                             f"Expected one of: {', '.join(allowed_types)}"
                         )
 


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: Log Injection / Secret Leakage. The `ValueError` raised for an invalid `Content-Type` in the `_gh_get` fallback HTTP request branch included the raw, unsanitized `url`. This could expose sensitive query parameters (like `token`, `secret`, `password`) in application logs if the exception is caught and logged, which is a critical security risk.
🎯 **Impact**: If an attacker or standard operation triggered a fallback request to a URL with an invalid `Content-Type`, any sensitive tokens in the URL would be written to plain text logs, potentially exposing authentication credentials to unauthorized internal or external users.
🔧 **Fix**: Modified `main.py` to wrap the `url` variable with the existing `sanitize_for_log()` function within the exception string, matching the sanitization pattern correctly used in the primary request branch.
✅ **Verification**: Verified the change by running a targeted test simulating the log injection and confirming `[REDACTED]` appeared in the error string instead of the raw token. Ran the full test suite (`uv run pytest`) to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [7282381428706749090](https://jules.google.com/task/7282381428706749090) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/ctrld-sync/pull/787" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->