### PR TITLE
🎨 Palette: Align plan details output

### DIFF
--- a/main.py
+++ b/main.py
@@ -678,11 +678,11 @@ def print_plan_details(plan_entry: PlanEntry) -> None:
 
         if USE_COLORS:
             print(
-                f"  • {Colors.BOLD}{name:<{max_name_len}}{Colors.ENDC} : {formatted_rules:>{max_rules_len}} {pluralize(rules_count, 'rule')} {action_text}"
+                f"  • {Colors.BOLD}{name:<{max_name_len}}{Colors.ENDC} : {formatted_rules:>{max_rules_len}} {pluralize(rules_count, 'rule'):<5} {action_text}"
             )
         else:
             print(
-                f"  - {name:<{max_name_len}} : {formatted_rules:>{max_rules_len}} {pluralize(rules_count, 'rule')} {action_text}"
+                f"  - {name:<{max_name_len}} : {formatted_rules:>{max_rules_len}} {pluralize(rules_count, 'rule'):<5} {action_text}"
             )
 
     print("")


### PR DESCRIPTION
💡 **What:** Aligned the plan details output by formatting the `rules` count label to a fixed width of 5 characters (`<5`).

🎯 **Why:** To prevent misalignment of the trailing action tags (`⛔ Block`, `✅ Allow`) when the word switches between `rule` (4 chars) and `rules` (5 chars).

📸 **Before/After:** The action tags now align perfectly across all rows regardless of the rule count.

♿ **Accessibility:** Cleaner visual structure improves scannability for all users.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/ctrld-sync/pull/809" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->