### PR TITLE
refactor(gh): Simplify deeply nested logic in _gh_get (salvages #806)

### DIFF
--- a/api_client.py
+++ b/api_client.py
@@ -215,28 +215,6 @@ def retry_with_jitter(
     return exponential_delay * random.random()
 
 
-def _log_debug_response(e: Exception) -> None:
-    """Log the response content if debug logging is enabled and response is present."""
-    if (
-        hasattr(e, "response")
-        and getattr(e, "response", None) is not None
-        and log.isEnabledFor(logging.DEBUG)
-    ):
-        log.debug(f"Response content: {_sanitize_fn(e.response.text)}")
-
-
-def _get_retry_after_seconds(response: httpx.Response) -> int | None:
-    """Extract and parse the Retry-After header as integer seconds, or None if missing/invalid."""
-    retry_after = response.headers.get("Retry-After")
-    if not retry_after:
-        return None
-    import contextlib
-
-    with contextlib.suppress(ValueError):
-        return int(retry_after)
-    return None
-
-
 def _retry_request(
     request_func: Callable[[], httpx.Response],
     max_retries: int = MAX_RETRIES,
@@ -280,16 +258,23 @@ def _retry_request(
 
                 # Handle 429 (Too Many Requests) with Retry-After
                 if code == 429:
-                    wait_seconds = _get_retry_after_seconds(e.response)
-                    if wait_seconds is not None:
-                        log.warning(
-                            f"Rate limited (429). Server requests {wait_seconds}s wait "
-                            f"(attempt {attempt + 1}/{max_retries})"
-                        )
-                        if attempt < max_retries - 1:
-                            time.sleep(wait_seconds)
-                            continue  # Retry after waiting
-                        raise  # Max retries exceeded
+                    # Check for Retry-After header (in seconds)
+                    retry_after = e.response.headers.get("Retry-After")
+                    if retry_after:
+                        # Retry-After can be seconds or HTTP date format.
+                        # Only suppress ValueError from int() parsing; leave all other logic outside.
+                        wait_seconds: int | None = None
+                        with contextlib.suppress(ValueError):
+                            wait_seconds = int(retry_after)
+                        if wait_seconds is not None:
+                            log.warning(
+                                f"Rate limited (429). Server requests {wait_seconds}s wait "
+                                f"(attempt {attempt + 1}/{max_retries})"
+                            )
+                            if attempt < max_retries - 1:
+                                time.sleep(wait_seconds)
+                                continue  # Retry after waiting
+                            raise  # Max retries exceeded
 
                 # Don't retry other 4xx errors (auth failures, bad requests, etc.)
                 if 400 <= code < 500 and code != 429:
@@ -299,7 +284,12 @@ def _retry_request(
                         f"API request failed with HTTP {code}{hint_suffix}: "
                         f"{_sanitize_fn(e)}"
                     )
-                    _log_debug_response(e)
+                    if (
+                        hasattr(e, "response")
+                        and e.response is not None
+                        and log.isEnabledFor(logging.DEBUG)
+                    ):
+                        log.debug(f"Response content: {_sanitize_fn(e.response.text)}")
                     raise
 
             if attempt == max_retries - 1:

--- a/main.py
+++ b/main.py
@@ -1595,7 +1595,7 @@ def _gh_get(url: str) -> dict:
             allowed_types = ["application/json", "text/json", "text/plain"]
             if not any(t in content_type for t in allowed_types):
                 raise ValueError(
-                    f"Invalid Content-Type from {sanitize_for_log(url)}: {content_type}. "
+                    f"Invalid Content-Type from {sanitize_for_log(url)}: {sanitize_for_log(content_type)}. "
                     f"Expected one of: {', '.join(allowed_types)}"
                 )
 

--- a/main.py
+++ b/main.py
@@ -678,11 +678,11 @@ def print_plan_details(plan_entry: PlanEntry) -> None:
 
         if USE_COLORS:
             print(
-                f"  • {Colors.BOLD}{name:<{max_name_len}}{Colors.ENDC} : {formatted_rules:>{max_rules_len}} {pluralize(rules_count, 'rule'):<5} {action_text}"
+                f"  • {Colors.BOLD}{name:<{max_name_len}}{Colors.ENDC} : {formatted_rules:>{max_rules_len}} {pluralize(rules_count, 'rule')} {action_text}"
             )
         else:
             print(
-                f"  - {name:<{max_name_len}} : {formatted_rules:>{max_rules_len}} {pluralize(rules_count, 'rule'):<5} {action_text}"
+                f"  - {name:<{max_name_len}} : {formatted_rules:>{max_rules_len}} {pluralize(rules_count, 'rule')} {action_text}"
             )
 
     print("")
@@ -1528,7 +1528,7 @@ def _gh_get(url: str) -> dict:
                     allowed_types = ["application/json", "text/json", "text/plain"]
                     if not any(t in content_type for t in allowed_types):
                         raise ValueError(
-                            f"Invalid Content-Type from {sanitize_for_log(url)}: {sanitize_for_log(content_type)}. "
+                            f"Invalid Content-Type from {url}: {content_type}. "
                             f"Expected one of: {', '.join(allowed_types)}"
                         )
 
@@ -1594,7 +1594,7 @@ def _gh_get(url: str) -> dict:
             allowed_types = ["application/json", "text/json", "text/plain"]
             if not any(t in content_type for t in allowed_types):
                 raise ValueError(
-                    f"Invalid Content-Type from {sanitize_for_log(url)}: {sanitize_for_log(content_type)}. "
+                    f"Invalid Content-Type from {sanitize_for_log(url)}: {content_type}. "
                     f"Expected one of: {', '.join(allowed_types)}"
                 )
 

--- a/main.py
+++ b/main.py
@@ -1528,7 +1528,8 @@ def _gh_get(url: str) -> dict:
                     allowed_types = ["application/json", "text/json", "text/plain"]
                     if not any(t in content_type for t in allowed_types):
                         raise ValueError(
-                            f"Invalid Content-Type from {url}: {content_type}. "
+                            f"Invalid Content-Type from {sanitize_for_log(url)}: "
+                            f"{sanitize_for_log(content_type)}. "
                             f"Expected one of: {', '.join(allowed_types)}"
                         )
 


### PR DESCRIPTION
## Agent ELIR, Expected behavior, Logs, Impact, Rollback

**Agent:** Automated PR Salvage & Recovery Agent v1.0  
**Source PR:** #806  
**Strategy:** Fresh-from-main branch with production-file checkout from PR head (excludes scratch scripts)

| Aspect | Details |
|--------|---------|
| **Expected behavior** | Simplify deeply nested logic in `_gh_get` / related GitHub API client paths without changing external behavior. |
| **Original issue** | #806 is CONFLICTING; prior salvage branch `salvage/pr-806-mainline` only contained scratch test files, not production changes. |
| **Salvage approach** | Checked out `api_client.py` and `main.py` from PR #806 head onto current `main`; omitted non-production scratch scripts (`test_gh_get.py`, `test_extract_refactor.py`). |
| **Files changed** | `api_client.py`, `main.py` |
| **Tests run** | `python3 -m py_compile api_client.py main.py` (pass). Full pytest suite not run locally (pytest not installed in salvage env). |
| **Verification** | Run repo CI / `pytest` after install; review `_gh_get` and `api_client.py` diff vs `main`. |
| **Rollback** | `git revert <merge-commit>` if merged |
| **Risk assessment** | **MEDIUM** — refactor of networking/cache code; verify blocklist fetch behavior unchanged. |

Supersedes conflicting PR #806. Original closed in favor of this draft.
