### PR TITLE
fix(tests): resolve mypy type error in test_ux.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -2187,7 +2187,6 @@ def create_folder(ctx: SyncContext, name: str, action: RuleAction) -> str | None
         return None
 
 
-
 def _filter_rules_for_folder(
     existing_rules: set[str],
     hostnames: list[str],
@@ -2870,7 +2869,11 @@ def print_summary_table(
             f"\n{('DRY RUN' if dry_run else 'SYNC') + ' SUMMARY':^{len(header)}}\n{sep}\n{header}\n{sep}"
         )
         for r in sync_results:
-            display_profile = "(Unspecified)" if r['profile'] == "dry-run-placeholder" else r['profile']
+            display_profile = (
+                "(Unspecified)"
+                if r["profile"] == "dry-run-placeholder"
+                else r["profile"]
+            )
             print(
                 f"{display_profile:<{w[0]}} | {r['folders']:>{w[1]}} | {r['rules']:>{w[2]},} | {r['duration']:>{w[3] - 1}.1f}s | {r['status_label']:<{w[4]}}"
             )
@@ -3302,7 +3305,11 @@ def main() -> None:
         s_rules = f"{res['rules']:,}"
         s_duration = f"{res['duration']:.1f}s"
 
-        display_profile = "(Unspecified)" if res["profile"] == "dry-run-placeholder" else res["profile"]
+        display_profile = (
+            "(Unspecified)"
+            if res["profile"] == "dry-run-placeholder"
+            else res["profile"]
+        )
         print(
             f"{Box.V} {display_profile:<{w_profile}} "
             f"{Box.V} {s_folders:>{w_folders}} "

--- a/tests/test_ux.py
+++ b/tests/test_ux.py
@@ -631,16 +631,19 @@ class TestGetPasswordHint:
             f"hint should not be duplicated, got: {prompt!r}"
         )
 
+
 def test_print_plan_details_dry_run_placeholder(monkeypatch, capsys):
     monkeypatch.setattr(main, "USE_COLORS", False)
-    plan_entry = {"profile": "dry-run-placeholder", "folders": []}
+    plan_entry = main.PlanEntry(profile="dry-run-placeholder", folders=[])
     main.print_plan_details(plan_entry)
     captured = capsys.readouterr()
     assert "Plan Details for (Unspecified):" in captured.out
 
+
 def test_print_summary_table_dry_run_placeholder(monkeypatch, capsys):
     monkeypatch.setattr(main, "USE_COLORS", False)
     from main import SyncResult
+
     sync_results = [
         SyncResult(
             profile="dry-run-placeholder",


### PR DESCRIPTION
**What:** Resolves mypy type error in `tests/test_ux.py` by using `main.PlanEntry` instead of a plain dict.
**Why:** `print_plan_details` expects a TypedDict `PlanEntry`, causing `uv run mypy .` to fail.
**Impact:** Fixes CI type checks.
**Measurement:** `uv run mypy .` passes without errors.