### PR TITLE
🛡️ Sentinel: [MEDIUM] Sanitize Content-Length header in error logs

### DIFF
--- a/main.py
+++ b/main.py
@@ -1560,7 +1560,7 @@ def _gh_get(url: str) -> dict:
                             if "Response too large" in str(e):
                                 raise
                             log.warning(
-                                f"Malformed Content-Length header from {sanitize_for_log(url)}: {cl!r}. "
+                                f"Malformed Content-Length header from {sanitize_for_log(url)}: {sanitize_for_log(cl)}. "
                                 "Falling back to streaming size check."
                             )
 
@@ -1626,7 +1626,7 @@ def _gh_get(url: str) -> dict:
                     if "Response too large" in str(e):
                         raise
                     log.warning(
-                        f"Malformed Content-Length header from {sanitize_for_log(url)}: {cl!r}. "
+                        f"Malformed Content-Length header from {sanitize_for_log(url)}: {sanitize_for_log(cl)}. "
                         "Falling back to streaming size check."
                     )
 


### PR DESCRIPTION
**Severity:** MEDIUM
**Vulnerability:** The `Content-Length` header value was being logged directly using `!r` format specifier without passing through `sanitize_for_log()`. This could allow an attacker to inject malicious strings or leak sensitive data via log files if they return a malicious `Content-Length` header.
**Impact:** Log injection, potential credential leakage.
**Fix:** Replaced `{cl!r}` with `{sanitize_for_log(cl)}` in the error logging statements in both the primary and fallback fetch paths.
**Verification:** Executed `uv run pytest` successfully.