### PR TITLE
chore(tests): fix mypy type mismatch in test_ux.py PlanEntry creation

### DIFF
--- a/tests/test_ux.py
+++ b/tests/test_ux.py
@@ -633,7 +633,7 @@ class TestGetPasswordHint:
 
 def test_print_plan_details_dry_run_placeholder(monkeypatch, capsys):
     monkeypatch.setattr(main, "USE_COLORS", False)
-    plan_entry = {"profile": "dry-run-placeholder", "folders": []}
+    plan_entry = main.PlanEntry(profile="dry-run-placeholder", folders=[])
     main.print_plan_details(plan_entry)
     captured = capsys.readouterr()
     assert "Plan Details for (Unspecified):" in captured.out


### PR DESCRIPTION
**What:** Fixed mypy `[arg-type]` inference errors in `tests/test_ux.py` where a standard dictionary literal was incorrectly passed to `print_plan_details` instead of the strictly expected `TypedDict` (`main.PlanEntry`).
**Why:** Passing `{"profile": "dry-run-placeholder", "folders": []}` triggers a mypy error because `print_plan_details` expects a `PlanEntry`. The explicit instantiation `main.PlanEntry(profile="dry-run-placeholder", folders=[])` ensures strict type checking passes.
**Before/After:** Before, running `uv run mypy tests/test_ux.py` would result in an error. After, no issues are found.
**Accessibility:** N/A

---
*PR created automatically by Jules for task [8014319285510253114](https://jules.google.com/task/8014319285510253114) started by @abhimehro*