### PR TITLE
⚡ Bolt: Add chunk_size to fallback HTTP streaming

### DIFF
--- a/main.py
+++ b/main.py
@@ -1567,7 +1567,8 @@ def _gh_get(url: str) -> dict:
                     # 2. Stream and check actual size
                     chunks = []
                     current_size = 0
-                    for chunk in r_retry.iter_bytes():
+                    # Optimization: Use 16KB chunks to reduce loop overhead/appends for large files
+                    for chunk in r_retry.iter_bytes(chunk_size=16 * 1024):
                         current_size += len(chunk)
                         if current_size > MAX_RESPONSE_SIZE:
                             raise ValueError(


### PR DESCRIPTION
💡 What: Added chunk_size=16*1024 to the r_retry.iter_bytes() call in the fallback HTTP streaming path.
🎯 Why: Without a specified chunk size, iter_bytes() yields tiny chunks, causing unnecessary loop overhead and many tiny appends to the chunks list, particularly for large payloads.
📊 Impact: Reduces loop iterations and list appends for the fallback fetch logic, improving performance when fetching large datasets and reducing CPU overhead, matching the main fetch logic.
🔬 Measurement: Review memory usage and CPU time during fallback HTTP fetches on large payloads.

---
*PR created automatically by Jules for task [6231350038773542620](https://jules.google.com/task/6231350038773542620) started by @abhimehro*