### PR TITLE
🎨 Palette: Fix dynamic pluralization on folder count

### DIFF
--- a/main.py
+++ b/main.py
@@ -2738,7 +2738,7 @@ def sync_profile(
                         )
 
         log.info(
-            f"Sync complete: {success_count}/{len(folder_data_list)} {pluralize(len(folder_data_list), 'folder')} processed successfully"
+            f"Sync complete: {success_count}/{len(folder_data_list)} folders processed successfully"
         )
         return success_count == len(folder_data_list)
 


### PR DESCRIPTION
💡 What: Removed dynamic pluralization on 'folder' count in the 'Sync complete' log message. 
🎯 Why: The phrase 'X/Y folders' should always be plural, even when X=1 and Y=1, because standard English dictates a plural noun for fractional representations. 
📸 Before/After: Before it could print '1/1 folder', now it correctly prints '1/1 folders'. 
♿ Accessibility: No a11y improvements needed for this change.