### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix log injection via HTTPStatusError (salvages #835)

### DIFF
--- a/main.py
+++ b/main.py
@@ -1978,7 +1978,7 @@ def fetch_folder_data(url: str) -> FolderData:
         # and reason phrase (e.g., "401 Unauthorized") in addition to our hint.
         original_msg = str(e)
         raise httpx.HTTPStatusError(
-            f"{original_msg} | hint: {hint} | url: {sanitize_for_log(url)}",
+            f"{sanitize_for_log(original_msg)} | hint: {hint} | url: {sanitize_for_log(url)}",
             request=e.request,
             response=e.response,
         ) from e


### PR DESCRIPTION
🚨 **Severity:** MEDIUM

💡 **Vulnerability:** Unsanitized exception string (`str(e)`) from `httpx.HTTPStatusError` is embedded into a new exception message, potentially leaking sensitive URLs or query parameters (e.g., redacted tokens) into logs.

🎯 **Impact:** Maliciously constructed URLs or leaked credentials via unsanitized URLs can result in log injection or sensitive secret leakage in the application logs or end-user terminal.

🔧 **Fix:** Passed `original_msg` through `sanitize_for_log()` prior to raising `httpx.HTTPStatusError`, ensuring defense-in-depth against log leakage of internal URLs or parameters.

✅ **Verification:** Verified that creating a mocked `HTTPStatusError` and re-raising it prints a fully sanitized URL (with `[REDACTED]` for sensitive variables). Ran full test suite to ensure correctness.

---

**Note:** This is a clean re-creation of PR #835. The original PR was merged and then reverted because PR #841 needed to be merged first. This PR contains only the security fix without the pr_body.json metadata file.