### PR TITLE
🎨 Palette: Intercept dry-run-placeholder in colored table

### DIFF
--- a/main.py
+++ b/main.py
@@ -2872,10 +2872,13 @@ def print_summary_table(
 
     for r in sync_results:
         sc = Colors.GREEN if r["success"] else Colors.FAIL
+        display_profile = (
+            "(Unspecified)" if r["profile"] == "dry-run-placeholder" else r["profile"]
+        )
         print(
             print_row(
                 [
-                    r["profile"],
+                    display_profile,
                     str(r["folders"]),
                     f"{r['rules']:,}",
                     f"{r['duration']:.1f}s",


### PR DESCRIPTION
💡 What: Render dry-run-placeholder as (Unspecified) in colored table.
🎯 Why: Avoid leaking internal placeholder in the UI.
📸 Before/After: Shows dry-run-placeholder vs (Unspecified).
♿ Accessibility: None.

---
*PR created automatically by Jules for task [5959327228899040433](https://jules.google.com/task/5959327228899040433) started by @abhimehro*