### PR TITLE
🎨 Palette: Add dynamic pluralization for folder sync status

### DIFF
--- a/main.py
+++ b/main.py
@@ -2711,7 +2711,7 @@ def sync_profile(
                         )
 
         log.info(
-            f"Sync complete: {success_count}/{len(folder_data_list)} folders processed successfully"
+            f"Sync complete: {success_count}/{len(folder_data_list)} {pluralize(len(folder_data_list), 'folder')} processed successfully"
         )
         return success_count == len(folder_data_list)
 


### PR DESCRIPTION
💡 **What:** Added dynamic pluralization to the final sync completion log message.
🎯 **Why:** To make the interface output more grammatically correct and pleasant to read when exactly one folder is processed.
📸 **Before/After:** 
Before: `Sync complete: 1/1 folders processed successfully`
After: `Sync complete: 1/1 folder processed successfully`
♿ **Accessibility:** Enhances readability.