### PR TITLE
🎨 Palette: Clean up unspecified profile log presentation

### DIFF
--- a/main.py
+++ b/main.py
@@ -3161,7 +3161,10 @@ def main() -> bool:
                 )
                 continue
 
-            log.info("Starting sync for profile %s", profile_id)
+            display_profile = (
+                "(Unspecified)" if profile_id == "dry-run-placeholder" else profile_id
+            )
+            log.info("Starting sync for profile %s", display_profile)
             status = sync_profile(
                 profile_id,
                 folder_urls,

--- a/tests/test_ux.py
+++ b/tests/test_ux.py
@@ -365,7 +365,6 @@ class TestPromptForInteractiveRestart:
         monkeypatch.setattr(sys, "stdin", _DummyStdin(is_tty=False))
         # Should not raise exception or call execv
 
-
     def test_handles_keyboard_interrupt(self, monkeypatch, capsys):
         """Should handle Ctrl+C gracefully."""
         # Simulate running in an interactive TTY.
@@ -375,9 +374,6 @@ class TestPromptForInteractiveRestart:
             raise KeyboardInterrupt()
 
         monkeypatch.setattr("builtins.input", mock_input)
-
-
-
 
         assert main.prompt_for_interactive_restart(["123"]) is False
         captured = capsys.readouterr()
@@ -394,9 +390,6 @@ class TestPromptForInteractiveRestart:
                 return lambda _: val
 
             monkeypatch.setattr("builtins.input", make_mock_input(cancel_input))
-
-
-
 
             assert main.prompt_for_interactive_restart(["123"]) is False
             captured = capsys.readouterr()
@@ -421,9 +414,6 @@ class TestPromptForInteractiveRestart:
             return next(inputs)
 
         monkeypatch.setattr("builtins.input", mock_input)
-
-
-
 
         result = main.prompt_for_interactive_restart(["123"])
 


### PR DESCRIPTION
💡 What: Cleaned up the log statement when no profile is specified in `--dry-run` to output `(Unspecified)` instead of the internal `dry-run-placeholder` string.

🎯 Why: Leaking internal placeholder identifiers creates a confusing UI for users.

📸 Before/After: Before, logs read `Starting sync for profile dry-run-placeholder`. After, they read `Starting sync for profile (Unspecified)`.

♿ Accessibility: N/A
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/ctrld-sync/pull/861" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->