### PR TITLE
🎨 Palette: Prevent internal placeholder leak in dry-run CLI suggestion

### DIFF
--- a/main.py
+++ b/main.py
@@ -3349,7 +3349,11 @@ def main() -> bool:
             # Build the suggested command once so it stays consistent between
             # color and non-color output modes.
             cmd_parts = ["python", "main.py"]
-            p_str = ",".join(profile_ids) if profile_ids else "<your-profile-id>"
+            p_str = (
+                ",".join(profile_ids)
+                if profile_ids and profile_ids[0] != "dry-run-placeholder"
+                else "<your-profile-id>"
+            )
             cmd_parts.append(f"--profiles {p_str}")
 
             # Reconstruct other args if they were used (optional but helpful)


### PR DESCRIPTION
💡 What: Prevents the internal `dry-run-placeholder` string from leaking into the suggested CLI command when running a dry run without profile IDs.
🎯 Why: Leaking internal placeholder strings creates an unpolished and confusing UX for users who don't provide a profile ID.
📸 Before/After: Before, it would suggest `python main.py --profiles dry-run-placeholder`. After, it correctly suggests `python main.py --profiles <your-profile-id>`.
♿ Accessibility: Improves cognitive accessibility by providing clear, understandable placeholders rather than exposing internal logic.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/ctrld-sync/pull/882" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->