### PR TITLE
🎨 Palette: Align summary table title with emojis

### DIFF
--- a/.github/scripts/repository_automation_common.py
+++ b/.github/scripts/repository_automation_common.py
@@ -146,9 +146,7 @@ def build_result(
     return result
 
 
-def write_result(
-    result: dict[str, Any], body: str
-) -> dict[str, Any]:
+def write_result(result: dict[str, Any], body: str) -> dict[str, Any]:
     task = result["task"]
     directory = task_dir(task)
     (directory / "report.md").write_text(body.rstrip() + "\n")

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -55,3 +55,7 @@
 
 **Learning:** When displaying data tables or CLI interfaces that fall back to placeholders for empty or unsaved state (e.g., `dry-run-placeholder` internally used when no profile is given), leaking the literal placeholder string creates an unpolished and confusing UX.
 **Action:** Always intercept placeholder constants at the UI boundary and render them as clean, human-readable strings like `(Unspecified)` or `(None)`.
+## 2025-05-18 - [CLI Emoji Alignment]
+
+**Learning:** When generating CLI tables with emojis or full-width characters in the title or headers, using `len()` causes incorrect padding because these characters occupy 2 terminal columns but only count as length 1. This creates broken borders and a misaligned UX.
+**Action:** Always use a custom display width calculation (e.g. `_display_len`) based on `unicodedata.east_asian_width` instead of `len()` for padding text that contains emojis or full-width characters.

--- a/main.py
+++ b/main.py
@@ -2819,7 +2819,7 @@ def print_line(left_char: str, mid_char: str, right_char: str, w: list[int]) -> 
 
 def _display_len(s: str) -> int:
     """Calculate display width of a string considering full-width characters."""
-    return sum(2 if unicodedata.east_asian_width(c) in ('W', 'F') else 1 for c in s)
+    return sum(2 if unicodedata.east_asian_width(c) in ("W", "F") else 1 for c in s)
 
 
 def _pad_string(s: str, width: int, align: str = "<") -> str:
@@ -3281,8 +3281,8 @@ def main() -> bool:
     # Title Row
     visible_title = title_text.strip()
     inner_width = table_width - 2
-    pad_left = (inner_width - len(visible_title)) // 2
-    pad_right = inner_width - len(visible_title) - pad_left
+    pad_left = (inner_width - _display_len(visible_title)) // 2
+    pad_right = inner_width - _display_len(visible_title) - pad_left
     print(
         f"{Box.V}{' ' * pad_left}{title_color}{visible_title}{Colors.ENDC}{' ' * pad_right}{Box.V}"
     )
@@ -3321,7 +3321,9 @@ def main() -> bool:
             else res["profile"]
         )
         status_text = f"{status_color}{res['status_label']}{Colors.ENDC}"
-        padded_status = status_text + " " * max(0, w_status - _display_len(res['status_label']))
+        padded_status = status_text + " " * max(
+            0, w_status - _display_len(res["status_label"])
+        )
 
         print(
             f"{Box.V} {_pad_string(display_profile, w_profile, '<')} "
@@ -3353,7 +3355,9 @@ def main() -> bool:
     s_total_duration = f"{total_duration:.1f}s"
 
     total_status = f"{total_status_color}{total_status_text}{Colors.ENDC}"
-    padded_total_status = total_status + " " * max(0, w_status - _display_len(total_status_text))
+    padded_total_status = total_status + " " * max(
+        0, w_status - _display_len(total_status_text)
+    )
 
     print(
         f"{Box.V} {Colors.BOLD}{_pad_string('TOTAL', w_profile, '<')}{Colors.ENDC} "


### PR DESCRIPTION
💡 What: Aligned the CLI table summary title borders by calculating string length based on display width.
🎯 Why: Emojis and full-width characters take up 2 terminal columns but Python length calculates them as 1, which causes the right-hand border to be misaligned.

===== ELIR =====
PURPOSE: Use _display_len for table title padding to fix CLI table border alignment.
SECURITY: No security implications (purely aesthetic display fix).
FAILS IF: None.
VERIFY: Ran --dry-run to visually inspect the summary table.
MAINTAIN: Always use _display_len when padding strings containing emojis.