### PR TITLE
🎨 Palette: Fix CLI table title border alignment

### DIFF
--- a/.github/scripts/repository_automation_common.py
+++ b/.github/scripts/repository_automation_common.py
@@ -146,9 +146,7 @@ def build_result(
     return result
 
 
-def write_result(
-    result: dict[str, Any], body: str
-) -> dict[str, Any]:
+def write_result(result: dict[str, Any], body: str) -> dict[str, Any]:
     task = result["task"]
     directory = task_dir(task)
     (directory / "report.md").write_text(body.rstrip() + "\n")

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -55,3 +55,7 @@
 
 **Learning:** When displaying data tables or CLI interfaces that fall back to placeholders for empty or unsaved state (e.g., `dry-run-placeholder` internally used when no profile is given), leaking the literal placeholder string creates an unpolished and confusing UX.
 **Action:** Always intercept placeholder constants at the UI boundary and render them as clean, human-readable strings like `(Unspecified)` or `(None)`.
+## 2025-06-13 - [CLI Empty State UI]
+
+**Learning:** When displaying data tables or CLI interfaces that calculate widths for alignment (e.g., using `len()` for padding calculations), emojis and full-width characters cause misalignment because they occupy 2 columns in the terminal but count as 1 character in Python's `len()`.
+**Action:** Always use a custom display width calculation (like `unicodedata.east_asian_width` or `_display_len`) when calculating padding around strings that may contain emojis or full-width characters to ensure perfect alignment.

--- a/main.py
+++ b/main.py
@@ -2819,7 +2819,7 @@ def print_line(left_char: str, mid_char: str, right_char: str, w: list[int]) -> 
 
 def _display_len(s: str) -> int:
     """Calculate display width of a string considering full-width characters."""
-    return sum(2 if unicodedata.east_asian_width(c) in ('W', 'F') else 1 for c in s)
+    return sum(2 if unicodedata.east_asian_width(c) in ("W", "F") else 1 for c in s)
 
 
 def _pad_string(s: str, width: int, align: str = "<") -> str:
@@ -3281,8 +3281,8 @@ def main() -> bool:
     # Title Row
     visible_title = title_text.strip()
     inner_width = table_width - 2
-    pad_left = (inner_width - len(visible_title)) // 2
-    pad_right = inner_width - len(visible_title) - pad_left
+    pad_left = (inner_width - _display_len(visible_title)) // 2
+    pad_right = inner_width - _display_len(visible_title) - pad_left
     print(
         f"{Box.V}{' ' * pad_left}{title_color}{visible_title}{Colors.ENDC}{' ' * pad_right}{Box.V}"
     )
@@ -3321,7 +3321,9 @@ def main() -> bool:
             else res["profile"]
         )
         status_text = f"{status_color}{res['status_label']}{Colors.ENDC}"
-        padded_status = status_text + " " * max(0, w_status - _display_len(res['status_label']))
+        padded_status = status_text + " " * max(
+            0, w_status - _display_len(res["status_label"])
+        )
 
         print(
             f"{Box.V} {_pad_string(display_profile, w_profile, '<')} "
@@ -3353,7 +3355,9 @@ def main() -> bool:
     s_total_duration = f"{total_duration:.1f}s"
 
     total_status = f"{total_status_color}{total_status_text}{Colors.ENDC}"
-    padded_total_status = total_status + " " * max(0, w_status - _display_len(total_status_text))
+    padded_total_status = total_status + " " * max(
+        0, w_status - _display_len(total_status_text)
+    )
 
     print(
         f"{Box.V} {Colors.BOLD}{_pad_string('TOTAL', w_profile, '<')}{Colors.ENDC} "


### PR DESCRIPTION
**💡 What:** Replaced `len(visible_title)` with `_display_len(visible_title)` to fix CLI table border alignment.
**🎯 Why:** Emojis take 2 columns in terminal output. Using `len()` underestimates the width by 1, pushing the right border of the title row out of alignment. Using `_display_len()` correctly factors in emoji display width, resulting in a perfectly aligned table.
**♿ Accessibility:** Improves visual consistency for sighted users reading the CLI summary output.