### PR TITLE
fix(test): instantiate TypedDict instead of dict for mypy

### DIFF
--- a/.github/scripts/repository_automation_common.py
+++ b/.github/scripts/repository_automation_common.py
@@ -146,9 +146,7 @@ def build_result(
     return result
 
 
-def write_result(
-    result: dict[str, Any], body: str
-) -> dict[str, Any]:
+def write_result(result: dict[str, Any], body: str) -> dict[str, Any]:
     task = result["task"]
     directory = task_dir(task)
     (directory / "report.md").write_text(body.rstrip() + "\n")

--- a/main.py
+++ b/main.py
@@ -2819,7 +2819,7 @@ def print_line(left_char: str, mid_char: str, right_char: str, w: list[int]) -> 
 
 def _display_len(s: str) -> int:
     """Calculate display width of a string considering full-width characters."""
-    return sum(2 if unicodedata.east_asian_width(c) in ('W', 'F') else 1 for c in s)
+    return sum(2 if unicodedata.east_asian_width(c) in ("W", "F") else 1 for c in s)
 
 
 def _pad_string(s: str, width: int, align: str = "<") -> str:
@@ -3321,7 +3321,9 @@ def main() -> bool:
             else res["profile"]
         )
         status_text = f"{status_color}{res['status_label']}{Colors.ENDC}"
-        padded_status = status_text + " " * max(0, w_status - _display_len(res['status_label']))
+        padded_status = status_text + " " * max(
+            0, w_status - _display_len(res["status_label"])
+        )
 
         print(
             f"{Box.V} {_pad_string(display_profile, w_profile, '<')} "
@@ -3353,7 +3355,9 @@ def main() -> bool:
     s_total_duration = f"{total_duration:.1f}s"
 
     total_status = f"{total_status_color}{total_status_text}{Colors.ENDC}"
-    padded_total_status = total_status + " " * max(0, w_status - _display_len(total_status_text))
+    padded_total_status = total_status + " " * max(
+        0, w_status - _display_len(total_status_text)
+    )
 
     print(
         f"{Box.V} {Colors.BOLD}{_pad_string('TOTAL', w_profile, '<')}{Colors.ENDC} "

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -98,12 +98,14 @@ def test_push_rules_benchmark_10k(benchmark, overlap_ratio):
 def test_sum_sync_result_totals_benchmark(benchmark):
     """Guard sync summary totals: sum(generator) is preferred over sum([list comp])."""
     sync_results = [
-        {
-            "profile": f"profile-{i}",
-            "folders": i % 5,
-            "rules": i * 10,
-            "duration": 0.05 * i,
-        }
+        main.SyncResult(
+            profile=f"profile-{i}",
+            folders=i % 5,
+            rules=i * 10,
+            status_label="OK",
+            success=True,
+            duration=0.05 * i,
+        )
         for i in range(25)
     ]
 


### PR DESCRIPTION
Fixing mypy inference errors by replacing standard dictionaries with explicit instantiation of TypedDict main.SyncResult in benchmark tests.