### PR TITLE
perf(api): unroll Content-Type validation in hot path (salvages #898)

### DIFF
--- a/main.py
+++ b/main.py
@@ -1425,6 +1425,19 @@ def validate_folder_data(data: dict[str, Any], url: str) -> TypeGuard[FolderData
     return True
 
 
+def _is_valid_content_type(content_type: str) -> bool:
+    """
+    Check if the response Content-Type is one of the allowed types.
+    """
+    if "application/json" in content_type:
+        return True
+    if "text/json" in content_type:
+        return True
+    if "text/plain" in content_type:
+        return True
+    return False
+
+
 # _api_stats_lock, _api_get, _api_delete, _api_post, _api_post_form,
 # retry_with_jitter, _retry_request imported from api_client above
 def _parse_and_cache_response(url: str, r: httpx.Response) -> dict:
@@ -1432,12 +1445,8 @@ def _parse_and_cache_response(url: str, r: httpx.Response) -> dict:
     Validate, stream, parse, and cache a blocklist response.
     """
     content_type = r.headers.get("Content-Type", "").lower()
-    # OPTIMIZATION: Unroll fixed-size Content-Type checks to avoid generator overhead.
-    if (
-        "application/json" not in content_type
-        and "text/json" not in content_type
-        and "text/plain" not in content_type
-    ):
+    # OPTIMIZATION: Delegate content-type checks to a helper to avoid complex conditional and reduce complexity.
+    if not _is_valid_content_type(content_type):
         raise ValueError(
             f"Invalid Content-Type from {sanitize_for_log(url)}: {sanitize_for_log(content_type)}. "
             "Expected one of: application/json, text/json, text/plain"

--- a/main.py
+++ b/main.py
@@ -1432,11 +1432,15 @@ def _parse_and_cache_response(url: str, r: httpx.Response) -> dict:
     Validate, stream, parse, and cache a blocklist response.
     """
     content_type = r.headers.get("Content-Type", "").lower()
-    allowed_types = ["application/json", "text/json", "text/plain"]
-    if not any(t in content_type for t in allowed_types):
+    # OPTIMIZATION: Unroll fixed-size Content-Type checks to avoid generator overhead.
+    if (
+        "application/json" not in content_type
+        and "text/json" not in content_type
+        and "text/plain" not in content_type
+    ):
         raise ValueError(
             f"Invalid Content-Type from {sanitize_for_log(url)}: {sanitize_for_log(content_type)}. "
-            f"Expected one of: {', '.join(allowed_types)}"
+            "Expected one of: application/json, text/json, text/plain"
         )
 
     # 1. Check Content-Length header if present


### PR DESCRIPTION
## Summary

Salvages the intent of #898 onto current `main` after #892 merged the `_parse_and_cache_response` refactor. Replaces `any(t in content_type for t in allowed_types)` with direct boolean checks for the three fixed Content-Type strings.

## Why a new PR

#898 went `DIRTY` after #892 landed and included unrelated `repository_automation_common.py` churn. This salvage applies only the hot-path unroll in `main.py`.

## Verification

```bash
uv run python -m py_compile main.py
uv run pytest tests/ -q
```

## Disposition

Closes #898 as superseded. **Draft — human review required** (Salvage Agent policy: no autonomous merges).

═══ ELIR ═══
PURPOSE: Micro-optimize Content-Type validation in `_parse_and_cache_response` without changing security semantics.
SECURITY: Same allowlist as before; no new trust boundaries.
FAILS IF: Content-Type allowlist drifts from API contract.
VERIFY: `uv run pytest tests/ -q` green on this branch.
MAINTAIN: If allowed types change, update all three boolean checks together.