### PR TITLE
🎨 Palette: Fix CLI table alignment with ANSI colors

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -63,3 +63,6 @@
 ## 2025-03-04 - CLI Table Alignment with Emojis
 **Learning:** Python's standard `len()` and f-string padding mechanisms fail to correctly align CLI tables when dealing with emojis and full-width characters. These characters typically take 2 terminal columns but count as 1 character in standard string length calculations, causing visual misalignment.
 **Action:** Use a custom display width calculation leveraging `unicodedata.east_asian_width` to manually calculate and apply padding lengths for strings containing emojis or CJK characters.
+## 2025-02-28 - Fix CLI table alignment with ANSI colors
+**Learning:** ANSI color codes in strings affect Python's `len()`, which breaks table padding when calculating display width for CLI tables. This results in misaligned columns.
+**Action:** Strip ANSI escape sequences using regex (`\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])`) before calculating the display length to ensure accurate visual alignment.

--- a/main.py
+++ b/main.py
@@ -2756,10 +2756,16 @@ def print_line(left_char: str, mid_char: str, right_char: str, w: list[int]) -> 
     return f"{Colors.BOLD}{left_char}{mid_char.join('─' * (x + 2) for x in w)}{right_char}{Colors.ENDC}"
 
 
+_ANSI_ESCAPE_PATTERN = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+
+
 def _display_len(s: str) -> int:
     """Calculate display width of a string considering full-width characters."""
+    stripped = _ANSI_ESCAPE_PATTERN.sub("", s)
     # OPTIMIZATION: C-speed list comprehension avoids Python loop overhead
-    return len(s) + len([1 for c in s if unicodedata.east_asian_width(c) in ("W", "F")])
+    return len(stripped) + len(
+        [1 for c in stripped if unicodedata.east_asian_width(c) in ("W", "F")]
+    )
 
 
 def _pad_string(s: str, width: int, align: str = "<") -> str:


### PR DESCRIPTION
💡 What: Fixed CLI table alignment by stripping ANSI color codes when calculating display length.
🎯 Why: The previous `_display_len` calculation counted ANSI color codes as characters, resulting in misaligned columns in the sync summary table when `USE_COLORS` was active.
♿ Accessibility: Improves readability of the CLI summary table.

---
*PR created automatically by Jules for task [9225815330284221254](https://jules.google.com/task/9225815330284221254) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/ctrld-sync/pull/907" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->