### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix exception chaining data leakage

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -11,3 +11,7 @@
 **Vulnerability:** HTTP client error exception strings contained un-sanitized values (URLs with auth, or tokens in query parameters) when re-raised.
 **Learning:** Re-raising an exception like `raise e` without reconstructing it with a sanitized string propagates sensitive data up the call stack, which could leak into tracebacks or uncaught exception handlers.
 **Prevention:** Always reconstruct explicitly logged/re-raised `HTTPStatusError` objects using the `sanitize_for_log` equivalent, e.g., `raise httpx.HTTPStatusError(sanitize_fn(str(e)), ...) from e`.
+## 2025-06-17 - Exception Chaining Data Leakage
+**Vulnerability:** When re-raising sanitized exceptions (like `httpx.HTTPStatusError`), using `from e` attaches the original unsanitized exception to the `__cause__` attribute. This inadvertently leaks sensitive data (such as tokens in URLs or unsanitized original messages) into tracebacks and logging frameworks.
+**Learning:** Re-constructing an exception with a sanitized message is insufficient if the original exception is preserved in the exception chain.
+**Prevention:** Always explicitly suppress exception chaining by appending `from None` when re-raising a sanitized exception. Ensure you run auto-fixing linters afterward to clean up unused exception variables.

--- a/api_client.py
+++ b/api_client.py
@@ -288,7 +288,7 @@ def _check_client_error(e: httpx.HTTPStatusError) -> None:
             _sanitize_fn(str(e)),
             request=e.request,
             response=e.response,
-        ) from e
+        ) from None
 
 
 def _retry_request(

--- a/main.py
+++ b/main.py
@@ -1474,8 +1474,10 @@ def _parse_and_cache_response(url: str, r: httpx.Response) -> dict:
 
     try:
         data = json.loads(b"".join(chunks))
-    except json.JSONDecodeError as e:
-        raise ValueError(f"Invalid JSON response from {sanitize_for_log(url)}") from e
+    except json.JSONDecodeError:
+        raise ValueError(
+            f"Invalid JSON response from {sanitize_for_log(url)}"
+        ) from None
 
     # Store cache headers for future conditional requests
     etag = r.headers.get("ETag")
@@ -1889,7 +1891,7 @@ def fetch_folder_data(url: str) -> FolderData:
             f"{sanitize_for_log(original_msg)} | hint: {hint} | url: {sanitize_for_log(url)}",
             request=e.request,
             response=e.response,
-        ) from e
+        ) from None
     if not validate_folder_data(js, url):
         raise KeyError(f"Invalid folder data from {sanitize_for_log(url)}")
     return js


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Original unsanitized exceptions are attached to `__cause__` due to `from e`, leaking sensitive data into tracebacks and logs.
🎯 Impact: An attacker could extract tokens or secrets embedded in HTTP headers or exception messages through tracebacks or logging platforms.
🔧 Fix: Explicitly suppressed exception chaining by modifying `from e` to `from None` when re-raising sanitized `httpx.HTTPStatusError` and `ValueError`.
✅ Verification: Verify there are no unused `e` variables remaining via linter, and ensure tests pass.

---
*PR created automatically by Jules for task [9191217114373663864](https://jules.google.com/task/9191217114373663864) started by @abhimehro*