### PR TITLE
🛡️ Sentinel: [MEDIUM] Prevent Un-sanitized Exception Messages from Data Leakage

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -11,3 +11,8 @@
 **Vulnerability:** HTTP client error exception strings contained un-sanitized values (URLs with auth, or tokens in query parameters) when re-raised.
 **Learning:** Re-raising an exception like `raise e` without reconstructing it with a sanitized string propagates sensitive data up the call stack, which could leak into tracebacks or uncaught exception handlers.
 **Prevention:** Always reconstruct explicitly logged/re-raised `HTTPStatusError` objects using the `sanitize_for_log` equivalent, e.g., `raise httpx.HTTPStatusError(sanitize_fn(str(e)), ...) from e`.
+
+## $(date +%Y-%m-%d) - [Exception Chaining Leakage]
+**Vulnerability:** Re-raising sanitized exceptions utilizing `raise e` or `raise from e` keeps the unsanitized original exception linked within the `__cause__` attribute, meaning that standard tracebacks can still leak raw sensitive data.
+**Learning:** To prevent leakage via exception chaining, when a sanitized version of an exception is created to be re-raised or logged, the un-sanitized context from the original exception must be fully decoupled by appending `from None`.
+**Prevention:** Ensure that anytime a sanitized exception is raised to mitigate data leakage, `raise from None` is utilized rather than `raise from e` or implicitly linking the previous exception.

--- a/api_client.py
+++ b/api_client.py
@@ -288,7 +288,7 @@ def _check_client_error(e: httpx.HTTPStatusError) -> None:
             _sanitize_fn(str(e)),
             request=e.request,
             response=e.response,
-        ) from e
+        ) from None
 
 
 def _retry_request(

--- a/main.py
+++ b/main.py
@@ -1474,8 +1474,8 @@ def _parse_and_cache_response(url: str, r: httpx.Response) -> dict:
 
     try:
         data = json.loads(b"".join(chunks))
-    except json.JSONDecodeError as e:
-        raise ValueError(f"Invalid JSON response from {sanitize_for_log(url)}") from e
+    except json.JSONDecodeError:
+        raise ValueError(f"Invalid JSON response from {sanitize_for_log(url)}") from None
 
     # Store cache headers for future conditional requests
     etag = r.headers.get("ETag")
@@ -1889,7 +1889,7 @@ def fetch_folder_data(url: str) -> FolderData:
             f"{sanitize_for_log(original_msg)} | hint: {hint} | url: {sanitize_for_log(url)}",
             request=e.request,
             response=e.response,
-        ) from e
+        ) from None
     if not validate_folder_data(js, url):
         raise KeyError(f"Invalid folder data from {sanitize_for_log(url)}")
     return js


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Caught exceptions embedded in HTTP status errors lack proper sanitization, allowing malicious payloads and control characters to leak upstream through tracebacks.
🎯 Impact: An attacker can craft malicious URLs or inputs that would embed unsanitized inputs into stack traces or logs when HTTP errors are re-raised.
🔧 Fix: Prevented exception chaining leakage by switching to `raise ... from None` when catching standard JSON Decode Errors and re-raising HTTP Status errors.
✅ Verification: Format and lint checks ran successfully. The test suite has been successfully executed with `uv sync --all-extras && uv run pytest`.

---
*PR created automatically by Jules for task [7911678409195632345](https://jules.google.com/task/7911678409195632345) started by @abhimehro*