### PR TITLE
🎨 Palette: Fix plan details table alignment for wide characters

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -66,3 +66,6 @@
 ## 2025-10-24 - [CLI Table Alignment with ANSI Codes]
 **Learning:** Python calculates width by character count. ANSI color escape sequences take 0 columns, breaking border alignment.
 **Action:** Fix this by stripping ANSI escape sequences (e.g., via regex `\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])`) and using a custom display width calculation to accurately measure visual padding.
+## 2025-03-03 - CLI Plan Details Alignment Fix
+**Learning:** Python's standard `len()` and format alignment (`:<`) calculate widths by raw character count, causing visual misalignment in CLI tables when strings contain emojis or full-width characters (which take 2 visual columns but count as 1).
+**Action:** When printing structured CLI output like dry-run plan details, use a custom display width calculation (like `_display_len` via `unicodedata`) and custom padding logic (like `_pad_string`) instead of relying on standard f-string formatting.

--- a/main.py
+++ b/main.py
@@ -636,7 +636,7 @@ def print_plan_details(plan_entry: PlanEntry) -> None:
     # Calculate max width for alignment
     max_name_len = max(
         # Use the same default ("Unknown") as when printing, so alignment is accurate
-        (len(sanitize_for_log(f.get("name", "Unknown"))) for f in folders),
+        (_display_len(sanitize_for_log(f.get("name", "Unknown"))) for f in folders),
         default=0,
     )
     max_rules_len = max((len(f"{f.get('rules', 0):,}") for f in folders), default=0)
@@ -647,14 +647,15 @@ def print_plan_details(plan_entry: PlanEntry) -> None:
         formatted_rules = f"{rules_count:,}"
 
         action_text = _get_action_text(folder)
+        padded_name = _pad_string(name, max_name_len, "<")
 
         if USE_COLORS:
             print(
-                f"  • {Colors.BOLD}{name:<{max_name_len}}{Colors.ENDC} : {formatted_rules:>{max_rules_len}} {pluralize(rules_count, 'rule'):<5} {action_text}"
+                f"  • {Colors.BOLD}{padded_name}{Colors.ENDC} : {formatted_rules:>{max_rules_len}} {pluralize(rules_count, 'rule'):<5} {action_text}"
             )
         else:
             print(
-                f"  - {name:<{max_name_len}} : {formatted_rules:>{max_rules_len}} {pluralize(rules_count, 'rule'):<5} {action_text}"
+                f"  - {padded_name} : {formatted_rules:>{max_rules_len}} {pluralize(rules_count, 'rule'):<5} {action_text}"
             )
 
     print("")


### PR DESCRIPTION
💡 **What:** Replaced standard Python length-based formatting with display-width aware padding in the plan details output.
🎯 **Why:** To ensure correct visual alignment in the CLI even when folder names contain emojis or full-width characters.
♿ **Accessibility:** Improves readability of CLI output for all users by preventing broken table layouts.

---
*PR created automatically by Jules for task [11036278547626369226](https://jules.google.com/task/11036278547626369226) started by @abhimehro*