### PR TITLE
🎨 Palette: Handle EOF/Ctrl+C gracefully in restart prompt

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -69,3 +69,7 @@
 ## 2025-03-03 - CLI Plan Details Alignment Fix
 **Learning:** Python's standard `len()` and format alignment (`:<`) calculate widths by raw character count, causing visual misalignment in CLI tables when strings contain emojis or full-width characters (which take 2 visual columns but count as 1).
 **Action:** When printing structured CLI output like dry-run plan details, use a custom display width calculation (like `_display_len` via `unicodedata`) and custom padding logic (like `_pad_string`) instead of relying on standard f-string formatting.
+
+## 2023-10-27 - Graceful Failures on CLI Interactive Prompts
+**Learning:** Users often press `Ctrl+C` or `Ctrl+D` to exit prompts. If the input function does not catch `KeyboardInterrupt` or `EOFError`, the app crashes with a stack trace instead of failing securely/gracefully.
+**Action:** Always wrap `input()` in interactive CLI flows with proper exception handling to return securely.

--- a/main.py
+++ b/main.py
@@ -2698,7 +2698,11 @@ def _get_interactive_restart_confirmation() -> bool:
         # Flush stdout (and stderr) so the prompt is visible even if output is buffered or redirected
         sys.stdout.flush()
         sys.stderr.flush()
-        user_response = input(prompt).strip().lower()
+        try:
+            user_response = input(prompt).strip().lower()
+        except (KeyboardInterrupt, EOFError):
+            print(cancel_msg)
+            return False
 
         if user_response in ("", "y", "yes"):
             return True


### PR DESCRIPTION
💡 What: Added a try/except block to handle `KeyboardInterrupt` and `EOFError` when the user presses Ctrl+C or Ctrl+D during the interactive restart prompt.
🎯 Why: Users expect CLI tools to exit cleanly when using standard cancel inputs, instead of throwing unhandled exceptions.

---
*PR created automatically by Jules for task [10601665299450038333](https://jules.google.com/task/10601665299450038333) started by @abhimehro*