### PR TITLE
⚡ Bolt: Add fast path to _display_len for ascii strings

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,9 @@
 ## 2025-10-24 - sum(list_comprehension) vs sum(generator) for data aggregation
 **Learning:** For CPU-bound data parsing paths (like aggregating nested lists in `_build_plan_entry` and `_sync_profiles`), replacing a generator expression inside a `sum()` call with a list comprehension (e.g., `sum([len(...) for ...])`) is measurably faster (~20-30%) as it leverages C-level iteration and avoids Python's generator overhead.
 **Action:** Prefer `sum([list_comprehension])` over `sum(generator_expression)` for CPU-bound data aggregation paths in Python.
+## 2025-06-25 - Fast Path for String Processing
+**Learning:** The `_display_len` calculation uses expensive regex and unicodedata checks. For the vast majority of console output that is plain ASCII without ANSI codes, computing this overhead is unnecessary. A fast path check (`s.isascii() and '\x1b' not in s`) runs in pure C and avoids all overhead.
+**Action:** When performing complex parsing or filtering on strings (like stripping ANSI codes or calculating East Asian widths), always add an early return fast path for standard ASCII strings to bypass the expensive logic completely.
+## 2025-06-25 - Review Action: Careful with Fallback Strings
+**Learning:** When attempting to tighten typing by forcing `None` to `0` in a `.get()` lookup (e.g., `dict.get(val if val is not None else 0)`), I inadvertently bypassed the intended fallback behavior (which relied on the default argument of `.get()` when `val` was `None` instead of `0`).
+**Action:** Handle `None` explicitly before or outside dictionary lookups to preserve specific fallback behaviors.

--- a/main.py
+++ b/main.py
@@ -589,10 +589,15 @@ def _get_action_text(folder: PlanFolderEntry) -> str:
         if action_val not in (0, 1):
             action_val = folder.get("action")
 
-        label, icon, color = {
-            0: ("Block", "⛔", Colors.FAIL),
-            1: ("Allow", "✅", Colors.GREEN)
-        }.get(action_val, ("Block (Default)", "⛔", Colors.FAIL))
+        # For type checking without losing the fallback string behavior:
+        # We handle None explicitly by using the fallback, otherwise look it up
+        if action_val is None:
+            label, icon, color = ("Block (Default)", "⛔", Colors.FAIL)
+        else:
+            label, icon, color = {
+                0: ("Block", "⛔", Colors.FAIL),
+                1: ("Allow", "✅", Colors.GREEN),
+            }.get(action_val, ("Block (Default)", "⛔", Colors.FAIL))
 
     if USE_COLORS:
         return f"({color}{icon} {label}{Colors.ENDC})"
@@ -1702,20 +1707,20 @@ def verify_access_and_get_folders(
         except httpx.HTTPStatusError as e:
             code = e.response.status_code
             if code in (401, 403, 404):
-                ERROR_MESSAGES = {
+                error_messages = {
                     401: [
                         "❌ Authentication Failed: The API Token is invalid.",
-                        "   Please check your token at: https://controld.com/account/manage-account"
+                        "   Please check your token at: https://controld.com/account/manage-account",
                     ],
                     403: [
                         f"🚫 Access Denied: Token lacks permission for Profile {sanitize_for_log(profile_id)}."
                     ],
                     404: [
                         f"🔍 Profile Not Found: The ID '{sanitize_for_log(profile_id)}' does not exist.",
-                        "   Please verify the Profile ID from your Control D Dashboard URL."
-                    ]
+                        "   Please verify the Profile ID from your Control D Dashboard URL.",
+                    ],
                 }
-                for line in ERROR_MESSAGES.get(code, []):
+                for line in error_messages.get(code, []):
                     log.critical(f"{Colors.FAIL}{line}{Colors.ENDC}")
                 return None
 
@@ -1725,7 +1730,15 @@ def verify_access_and_get_folders(
 
         except httpx.RequestError as err:
             if attempt == MAX_RETRIES - 1:
-                hint = f" | hint: {_TIMEOUT_HINT}" if isinstance(err, httpx.TimeoutException) else (f" | hint: {_CONNECT_ERROR_HINT}" if isinstance(err, httpx.ConnectError) else "")
+                hint = (
+                    f" | hint: {_TIMEOUT_HINT}"
+                    if isinstance(err, httpx.TimeoutException)
+                    else (
+                        f" | hint: {_CONNECT_ERROR_HINT}"
+                        if isinstance(err, httpx.ConnectError)
+                        else ""
+                    )
+                )
                 log.error(
                     "Network error during access verification: %s%s",
                     sanitize_for_log(err),
@@ -2708,6 +2721,10 @@ _ANSI_ESCAPE_PATTERN = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
 
 def _display_len(s: str) -> int:
     """Calculate display width of a string considering full-width characters and ignoring ANSI codes."""
+    # FAST PATH: If string is plain ASCII without ANSI escapes, length is exact.
+    if s.isascii() and "\x1b" not in s:
+        return len(s)
+
     stripped = _ANSI_ESCAPE_PATTERN.sub("", s)
     # OPTIMIZATION: C-speed list comprehension avoids Python loop overhead
     return len(stripped) + len(
@@ -2973,7 +2990,11 @@ def display_rate_limit_status() -> None:
             limit = _rate_limit_info["limit"]
             if limit and limit > 0:
                 pct = (remaining / limit) * 100
-                color = Colors.FAIL if pct < 20 else (Colors.WARNING if pct < 50 else Colors.GREEN)
+                color = (
+                    Colors.FAIL
+                    if pct < 20
+                    else (Colors.WARNING if pct < 50 else Colors.GREEN)
+                )
                 print(
                     f"  • Requests remaining:   {color}{remaining:>6,} ({pct:>5.1f}%){Colors.ENDC}"
                 )


### PR DESCRIPTION
💡 **What:** Added a fast path to `_display_len` that immediately returns `len(s)` if the string is ASCII and contains no ANSI escape codes.

🎯 **Why:** `_display_len` is called frequently when rendering tables and logs. Previously, it performed a regex substitution and iterated over every character checking `unicodedata.east_asian_width` even for normal text.

📊 **Impact:** Significantly reduces CPU overhead and avoids unnecessary regex execution for standard text formatting.

🔬 **Measurement:** The impact is noticeable in profiles of `print_summary_table`.

---
*PR created automatically by Jules for task [1714004421982110339](https://jules.google.com/task/1714004421982110339) started by @abhimehro*