### PR TITLE
🎨 Palette: fix terminal line residue on interactive prompt cancellation

### DIFF
--- a/main.py
+++ b/main.py
@@ -212,6 +212,13 @@ class Colors:
         UNDERLINE = ""
         DIM = ""
 
+    @staticmethod
+    def clear_line() -> None:
+        """Helper to cleanly erase the current terminal line residue (e.g. ^C)."""
+        if USE_COLORS:
+            sys.stderr.write("\r\033[K")
+            sys.stderr.flush()
+
 
 class Box:
     """Box drawing characters for pretty tables."""
@@ -750,13 +757,6 @@ def _print_hint(hint: str) -> None:
         print(hint)
 
 
-def _clear_line_residue() -> None:
-    """Helper to cleanly erase the current terminal line residue (e.g. ^C)."""
-    if USE_COLORS:
-        sys.stderr.write("\r\033[K")
-        sys.stderr.flush()
-
-
 def get_validated_input(
     prompt: str,
     validator: Callable[[str], bool],
@@ -772,7 +772,7 @@ def get_validated_input(
             sys.stderr.flush()
             value = input(prompt).strip()
         except (KeyboardInterrupt, EOFError):
-            _clear_line_residue()
+            Colors.clear_line()
             print(f"\n{Colors.WARNING}⚠️  Input cancelled.{Colors.ENDC}")
             sys.exit(130)
 
@@ -813,7 +813,7 @@ def get_password(
             sys.stderr.flush()
             value = getpass.getpass(prompt).strip()
         except (KeyboardInterrupt, EOFError):
-            _clear_line_residue()
+            Colors.clear_line()
             print(f"\n{Colors.WARNING}⚠️  Input cancelled.{Colors.ENDC}")
             sys.exit(130)
 
@@ -2660,7 +2660,7 @@ def _get_interactive_restart_confirmation() -> bool:
         try:
             user_response = input(prompt).strip().lower()
         except (KeyboardInterrupt, EOFError):
-            _clear_line_residue()
+            Colors.clear_line()
             print(cancel_msg)
             return False
 
@@ -2715,7 +2715,7 @@ def prompt_for_interactive_restart(profile_ids: list[str]) -> bool:
         return True
 
     except (KeyboardInterrupt, EOFError):
-        _clear_line_residue()
+        Colors.clear_line()
         print(f"\n{Colors.WARNING}⚠️  Cancelled.{Colors.ENDC}")
         return False
 
@@ -3445,6 +3445,6 @@ if __name__ == "__main__":
         while main():
             pass
     except KeyboardInterrupt:
-        _clear_line_residue()
+        Colors.clear_line()
         print(f"\n{Colors.WARNING}⚠️  Cancelled by user.{Colors.ENDC}")
         sys.exit(130)

--- a/main.py
+++ b/main.py
@@ -765,6 +765,9 @@ def get_validated_input(
             sys.stderr.flush()
             value = input(prompt).strip()
         except (KeyboardInterrupt, EOFError):
+            if USE_COLORS:
+                sys.stderr.write("\r\033[K")
+                sys.stderr.flush()
             print(f"\n{Colors.WARNING}⚠️  Input cancelled.{Colors.ENDC}")
             sys.exit(130)
 
@@ -805,6 +808,9 @@ def get_password(
             sys.stderr.flush()
             value = getpass.getpass(prompt).strip()
         except (KeyboardInterrupt, EOFError):
+            if USE_COLORS:
+                sys.stderr.write("\r\033[K")
+                sys.stderr.flush()
             print(f"\n{Colors.WARNING}⚠️  Input cancelled.{Colors.ENDC}")
             sys.exit(130)
 
@@ -2651,6 +2657,9 @@ def _get_interactive_restart_confirmation() -> bool:
         try:
             user_response = input(prompt).strip().lower()
         except (KeyboardInterrupt, EOFError):
+            if USE_COLORS:
+                sys.stderr.write("\r\033[K")
+                sys.stderr.flush()
             print(cancel_msg)
             return False
 
@@ -2705,6 +2714,9 @@ def prompt_for_interactive_restart(profile_ids: list[str]) -> bool:
         return True
 
     except (KeyboardInterrupt, EOFError):
+        if USE_COLORS:
+            sys.stderr.write("\r\033[K")
+            sys.stderr.flush()
         print(f"\n{Colors.WARNING}⚠️  Cancelled.{Colors.ENDC}")
         return False
 
@@ -3434,5 +3446,8 @@ if __name__ == "__main__":
         while main():
             pass
     except KeyboardInterrupt:
+        if USE_COLORS:
+            sys.stderr.write("\r\033[K")
+            sys.stderr.flush()
         print(f"\n{Colors.WARNING}⚠️  Cancelled by user.{Colors.ENDC}")
         sys.exit(130)

--- a/main.py
+++ b/main.py
@@ -87,7 +87,9 @@ class SyncContext:
     batch_executor: concurrent.futures.Executor | None = None
 
 
+# --------------------------------------------------------------------------- #
 # TypedDicts – document the shapes of API response and plan objects
+# --------------------------------------------------------------------------- #
 
 
 class FolderAction(TypedDict, total=False):
@@ -168,7 +170,9 @@ class SyncResult(TypedDict):
     duration: float
 
 
+# --------------------------------------------------------------------------- #
 # 0. Bootstrap – load secrets and configure logging
+# --------------------------------------------------------------------------- #
 # SECURITY: load_dotenv() moved to main() to ensure permissions are checked first
 
 # Respect NO_COLOR standard (https://no-color.org/)
@@ -453,7 +457,9 @@ def check_env_permissions(env_path: str = ".env") -> None:
 # SECURITY: Check .env permissions will be called in main() to avoid side effects at import time
 log = logging.getLogger("control-d-sync")
 
+# --------------------------------------------------------------------------- #
 # 1. Constants – tweak only here
+# --------------------------------------------------------------------------- #
 API_BASE = "https://api.controld.com/profiles"
 USER_AGENT = "Control-D-Sync/0.1.0"
 
@@ -759,8 +765,9 @@ def get_validated_input(
             sys.stderr.flush()
             value = input(prompt).strip()
         except (KeyboardInterrupt, EOFError):
-            sys.stderr.write("\r\033[K" if sys.stderr.isatty() else "")
-            sys.stderr.flush()
+            if sys.stderr.isatty():
+                sys.stderr.write("\r\033[K")
+                sys.stderr.flush()
             print(f"{Colors.WARNING}⚠️  Input cancelled.{Colors.ENDC}")
             sys.exit(130)
 
@@ -801,8 +808,9 @@ def get_password(
             sys.stderr.flush()
             value = getpass.getpass(prompt).strip()
         except (KeyboardInterrupt, EOFError):
-            sys.stderr.write("\r\033[K" if sys.stderr.isatty() else "")
-            sys.stderr.flush()
+            if sys.stderr.isatty():
+                sys.stderr.write("\r\033[K")
+                sys.stderr.flush()
             print(f"{Colors.WARNING}⚠️  Input cancelled.{Colors.ENDC}")
             sys.exit(130)
 
@@ -1029,17 +1037,23 @@ _gh = httpx.Client(
 )
 MAX_RESPONSE_SIZE = 10 * 1024 * 1024  # 10 MB limit for external resources
 
+# --------------------------------------------------------------------------- #
 # 3. Helpers
+# --------------------------------------------------------------------------- #
 _cache: dict[str, dict] = {}
 # Use RLock (reentrant lock) to allow nested acquisitions by the same thread
 # This prevents deadlocks when _fetch_if_valid calls fetch_folder_data which calls _gh_get
 _cache_lock = threading.RLock()
 
+# --------------------------------------------------------------------------- #
 # 3a. Persistent Disk Cache Support  (implementation lives in cache.py)
+# --------------------------------------------------------------------------- #
 
 # _api_stats imported from api_client above
 
+# --------------------------------------------------------------------------- #
 # 3b. Rate Limit Tracking
+# --------------------------------------------------------------------------- #
 # _rate_limit_info, _rate_limit_lock imported from api_client above
 
 
@@ -2350,7 +2364,9 @@ def _process_single_folder(
     return folder_success
 
 
+# --------------------------------------------------------------------------- #
 # 4. Main workflow
+# --------------------------------------------------------------------------- #
 def _fetch_all_folder_data(folder_urls: Sequence[str]) -> list[FolderData] | None:
     """Fetches folder data for all URLs in parallel."""
     folder_data_list: list[FolderData] = []
@@ -2622,7 +2638,9 @@ def sync_profile(
         return False
 
 
+# --------------------------------------------------------------------------- #
 # 5. Entry-point
+# --------------------------------------------------------------------------- #
 def _get_interactive_restart_confirmation() -> bool:
     """Helper to prompt for and validate interactive restart confirmation."""
     prompt_initial = f"\n{Colors.BOLD}🚀 Ready to launch? {Colors.ENDC}Press [Enter] to run now (or type 'n' / Ctrl+C to cancel)... "
@@ -2639,8 +2657,9 @@ def _get_interactive_restart_confirmation() -> bool:
         try:
             user_response = input(prompt).strip().lower()
         except (KeyboardInterrupt, EOFError):
-            sys.stderr.write("\r\033[K" if sys.stderr.isatty() else "")
-            sys.stderr.flush()
+            if sys.stderr.isatty():
+                sys.stderr.write("\r\033[K")
+                sys.stderr.flush()
             print(cancel_msg.lstrip("\n"))
             return False
 
@@ -2695,8 +2714,9 @@ def prompt_for_interactive_restart(profile_ids: list[str]) -> bool:
         return True
 
     except (KeyboardInterrupt, EOFError):
-        sys.stderr.write("\r\033[K" if sys.stderr.isatty() else "")
-        sys.stderr.flush()
+        if sys.stderr.isatty():
+            sys.stderr.write("\r\033[K")
+            sys.stderr.flush()
         print(f"{Colors.WARNING}⚠️  Cancelled.{Colors.ENDC}")
         return False
 
@@ -3426,7 +3446,8 @@ if __name__ == "__main__":
         while main():
             pass
     except KeyboardInterrupt:
-        sys.stderr.write("\r\033[K" if sys.stderr.isatty() else "")
-        sys.stderr.flush()
+        if sys.stderr.isatty():
+            sys.stderr.write("\r\033[K")
+            sys.stderr.flush()
         print(f"{Colors.WARNING}⚠️  Cancelled by user.{Colors.ENDC}")
         sys.exit(130)

--- a/main.py
+++ b/main.py
@@ -87,9 +87,7 @@ class SyncContext:
     batch_executor: concurrent.futures.Executor | None = None
 
 
-# --------------------------------------------------------------------------- #
 # TypedDicts – document the shapes of API response and plan objects
-# --------------------------------------------------------------------------- #
 
 
 class FolderAction(TypedDict, total=False):
@@ -170,9 +168,7 @@ class SyncResult(TypedDict):
     duration: float
 
 
-# --------------------------------------------------------------------------- #
 # 0. Bootstrap – load secrets and configure logging
-# --------------------------------------------------------------------------- #
 # SECURITY: load_dotenv() moved to main() to ensure permissions are checked first
 
 # Respect NO_COLOR standard (https://no-color.org/)
@@ -457,9 +453,7 @@ def check_env_permissions(env_path: str = ".env") -> None:
 # SECURITY: Check .env permissions will be called in main() to avoid side effects at import time
 log = logging.getLogger("control-d-sync")
 
-# --------------------------------------------------------------------------- #
 # 1. Constants – tweak only here
-# --------------------------------------------------------------------------- #
 API_BASE = "https://api.controld.com/profiles"
 USER_AGENT = "Control-D-Sync/0.1.0"
 
@@ -765,9 +759,8 @@ def get_validated_input(
             sys.stderr.flush()
             value = input(prompt).strip()
         except (KeyboardInterrupt, EOFError):
-            if sys.stderr.isatty():
-                sys.stderr.write("\r\033[K")
-                sys.stderr.flush()
+            sys.stderr.write("\r\033[K" if sys.stderr.isatty() else "")
+            sys.stderr.flush()
             print(f"{Colors.WARNING}⚠️  Input cancelled.{Colors.ENDC}")
             sys.exit(130)
 
@@ -808,9 +801,8 @@ def get_password(
             sys.stderr.flush()
             value = getpass.getpass(prompt).strip()
         except (KeyboardInterrupt, EOFError):
-            if sys.stderr.isatty():
-                sys.stderr.write("\r\033[K")
-                sys.stderr.flush()
+            sys.stderr.write("\r\033[K" if sys.stderr.isatty() else "")
+            sys.stderr.flush()
             print(f"{Colors.WARNING}⚠️  Input cancelled.{Colors.ENDC}")
             sys.exit(130)
 
@@ -1037,23 +1029,17 @@ _gh = httpx.Client(
 )
 MAX_RESPONSE_SIZE = 10 * 1024 * 1024  # 10 MB limit for external resources
 
-# --------------------------------------------------------------------------- #
 # 3. Helpers
-# --------------------------------------------------------------------------- #
 _cache: dict[str, dict] = {}
 # Use RLock (reentrant lock) to allow nested acquisitions by the same thread
 # This prevents deadlocks when _fetch_if_valid calls fetch_folder_data which calls _gh_get
 _cache_lock = threading.RLock()
 
-# --------------------------------------------------------------------------- #
 # 3a. Persistent Disk Cache Support  (implementation lives in cache.py)
-# --------------------------------------------------------------------------- #
 
 # _api_stats imported from api_client above
 
-# --------------------------------------------------------------------------- #
 # 3b. Rate Limit Tracking
-# --------------------------------------------------------------------------- #
 # _rate_limit_info, _rate_limit_lock imported from api_client above
 
 
@@ -2364,9 +2350,7 @@ def _process_single_folder(
     return folder_success
 
 
-# --------------------------------------------------------------------------- #
 # 4. Main workflow
-# --------------------------------------------------------------------------- #
 def _fetch_all_folder_data(folder_urls: Sequence[str]) -> list[FolderData] | None:
     """Fetches folder data for all URLs in parallel."""
     folder_data_list: list[FolderData] = []
@@ -2638,9 +2622,7 @@ def sync_profile(
         return False
 
 
-# --------------------------------------------------------------------------- #
 # 5. Entry-point
-# --------------------------------------------------------------------------- #
 def _get_interactive_restart_confirmation() -> bool:
     """Helper to prompt for and validate interactive restart confirmation."""
     prompt_initial = f"\n{Colors.BOLD}🚀 Ready to launch? {Colors.ENDC}Press [Enter] to run now (or type 'n' / Ctrl+C to cancel)... "
@@ -2657,9 +2639,8 @@ def _get_interactive_restart_confirmation() -> bool:
         try:
             user_response = input(prompt).strip().lower()
         except (KeyboardInterrupt, EOFError):
-            if sys.stderr.isatty():
-                sys.stderr.write("\r\033[K")
-                sys.stderr.flush()
+            sys.stderr.write("\r\033[K" if sys.stderr.isatty() else "")
+            sys.stderr.flush()
             print(cancel_msg.lstrip("\n"))
             return False
 
@@ -2714,9 +2695,8 @@ def prompt_for_interactive_restart(profile_ids: list[str]) -> bool:
         return True
 
     except (KeyboardInterrupt, EOFError):
-        if sys.stderr.isatty():
-            sys.stderr.write("\r\033[K")
-            sys.stderr.flush()
+        sys.stderr.write("\r\033[K" if sys.stderr.isatty() else "")
+        sys.stderr.flush()
         print(f"{Colors.WARNING}⚠️  Cancelled.{Colors.ENDC}")
         return False
 
@@ -3446,8 +3426,7 @@ if __name__ == "__main__":
         while main():
             pass
     except KeyboardInterrupt:
-        if sys.stderr.isatty():
-            sys.stderr.write("\r\033[K")
-            sys.stderr.flush()
+        sys.stderr.write("\r\033[K" if sys.stderr.isatty() else "")
+        sys.stderr.flush()
         print(f"{Colors.WARNING}⚠️  Cancelled by user.{Colors.ENDC}")
         sys.exit(130)

--- a/main.py
+++ b/main.py
@@ -750,6 +750,13 @@ def _print_hint(hint: str) -> None:
         print(hint)
 
 
+def _clear_line_residue() -> None:
+    """Helper to cleanly erase the current terminal line residue (e.g. ^C)."""
+    if USE_COLORS:
+        sys.stderr.write("\r\033[K")
+        sys.stderr.flush()
+
+
 def get_validated_input(
     prompt: str,
     validator: Callable[[str], bool],
@@ -765,9 +772,7 @@ def get_validated_input(
             sys.stderr.flush()
             value = input(prompt).strip()
         except (KeyboardInterrupt, EOFError):
-            if USE_COLORS:
-                sys.stderr.write("\r\033[K")
-                sys.stderr.flush()
+            _clear_line_residue()
             print(f"\n{Colors.WARNING}⚠️  Input cancelled.{Colors.ENDC}")
             sys.exit(130)
 
@@ -808,9 +813,7 @@ def get_password(
             sys.stderr.flush()
             value = getpass.getpass(prompt).strip()
         except (KeyboardInterrupt, EOFError):
-            if USE_COLORS:
-                sys.stderr.write("\r\033[K")
-                sys.stderr.flush()
+            _clear_line_residue()
             print(f"\n{Colors.WARNING}⚠️  Input cancelled.{Colors.ENDC}")
             sys.exit(130)
 
@@ -2657,9 +2660,7 @@ def _get_interactive_restart_confirmation() -> bool:
         try:
             user_response = input(prompt).strip().lower()
         except (KeyboardInterrupt, EOFError):
-            if USE_COLORS:
-                sys.stderr.write("\r\033[K")
-                sys.stderr.flush()
+            _clear_line_residue()
             print(cancel_msg)
             return False
 
@@ -2714,9 +2715,7 @@ def prompt_for_interactive_restart(profile_ids: list[str]) -> bool:
         return True
 
     except (KeyboardInterrupt, EOFError):
-        if USE_COLORS:
-            sys.stderr.write("\r\033[K")
-            sys.stderr.flush()
+        _clear_line_residue()
         print(f"\n{Colors.WARNING}⚠️  Cancelled.{Colors.ENDC}")
         return False
 
@@ -3446,8 +3445,6 @@ if __name__ == "__main__":
         while main():
             pass
     except KeyboardInterrupt:
-        if USE_COLORS:
-            sys.stderr.write("\r\033[K")
-            sys.stderr.flush()
+        _clear_line_residue()
         print(f"\n{Colors.WARNING}⚠️  Cancelled by user.{Colors.ENDC}")
         sys.exit(130)

--- a/main.py
+++ b/main.py
@@ -212,13 +212,6 @@ class Colors:
         UNDERLINE = ""
         DIM = ""
 
-    @staticmethod
-    def clear_line() -> None:
-        """Helper to cleanly erase the current terminal line residue (e.g. ^C)."""
-        if USE_COLORS:
-            sys.stderr.write("\r\033[K")
-            sys.stderr.flush()
-
 
 class Box:
     """Box drawing characters for pretty tables."""
@@ -772,8 +765,10 @@ def get_validated_input(
             sys.stderr.flush()
             value = input(prompt).strip()
         except (KeyboardInterrupt, EOFError):
-            Colors.clear_line()
-            print(f"\n{Colors.WARNING}⚠️  Input cancelled.{Colors.ENDC}")
+            if sys.stderr.isatty():
+                sys.stderr.write("\r\033[K")
+                sys.stderr.flush()
+            print(f"{Colors.WARNING}⚠️  Input cancelled.{Colors.ENDC}")
             sys.exit(130)
 
         if not value:
@@ -813,8 +808,10 @@ def get_password(
             sys.stderr.flush()
             value = getpass.getpass(prompt).strip()
         except (KeyboardInterrupt, EOFError):
-            Colors.clear_line()
-            print(f"\n{Colors.WARNING}⚠️  Input cancelled.{Colors.ENDC}")
+            if sys.stderr.isatty():
+                sys.stderr.write("\r\033[K")
+                sys.stderr.flush()
+            print(f"{Colors.WARNING}⚠️  Input cancelled.{Colors.ENDC}")
             sys.exit(130)
 
         if not value:
@@ -2660,8 +2657,10 @@ def _get_interactive_restart_confirmation() -> bool:
         try:
             user_response = input(prompt).strip().lower()
         except (KeyboardInterrupt, EOFError):
-            Colors.clear_line()
-            print(cancel_msg)
+            if sys.stderr.isatty():
+                sys.stderr.write("\r\033[K")
+                sys.stderr.flush()
+            print(cancel_msg.lstrip("\n"))
             return False
 
         if user_response in ("", "y", "yes"):
@@ -2715,8 +2714,10 @@ def prompt_for_interactive_restart(profile_ids: list[str]) -> bool:
         return True
 
     except (KeyboardInterrupt, EOFError):
-        Colors.clear_line()
-        print(f"\n{Colors.WARNING}⚠️  Cancelled.{Colors.ENDC}")
+        if sys.stderr.isatty():
+            sys.stderr.write("\r\033[K")
+            sys.stderr.flush()
+        print(f"{Colors.WARNING}⚠️  Cancelled.{Colors.ENDC}")
         return False
 
 
@@ -3445,6 +3446,8 @@ if __name__ == "__main__":
         while main():
             pass
     except KeyboardInterrupt:
-        Colors.clear_line()
-        print(f"\n{Colors.WARNING}⚠️  Cancelled by user.{Colors.ENDC}")
+        if sys.stderr.isatty():
+            sys.stderr.write("\r\033[K")
+            sys.stderr.flush()
+        print(f"{Colors.WARNING}⚠️  Cancelled by user.{Colors.ENDC}")
         sys.exit(130)

--- a/main.py
+++ b/main.py
@@ -2686,39 +2686,31 @@ def prompt_for_interactive_restart(profile_ids: list[str]) -> bool:
     if not sys.stdin.isatty():
         return False
 
-    try:
-        if not _get_interactive_restart_confirmation():
-            return False
-
-        # Prepare environment for the new process
-        # Pass the current token to avoid re-prompting if it was entered interactively
-        if TOKEN:
-            os.environ["TOKEN"] = TOKEN
-
-        # Construct command arguments
-        # Use sys.argv filtering to preserve all user-provided flags (even future ones)
-        # while removing --dry-run to switch to live mode.
-        clean_argv = [arg for arg in sys.argv[1:] if arg != "--dry-run"]
-        new_argv = [sys.executable, sys.argv[0]] + clean_argv
-
-        # If --profiles wasn't in original args (meaning it came from env/input),
-        # inject it explicitly so the user doesn't have to re-enter it.
-        if "--profiles" not in sys.argv and profile_ids:
-            new_argv.extend(["--profiles", ",".join(profile_ids)])
-
-        print(f"\n{Colors.GREEN}🔄 Restarting in live mode...{Colors.ENDC}")
-        # Modifying sys.argv in-place allows the main loop to pick up the new arguments
-        # without invoking os.execv, eliminating command injection risks entirely.
-        sys.argv.clear()
-        sys.argv.extend(new_argv)
-        return True
-
-    except (KeyboardInterrupt, EOFError):
-        if sys.stderr.isatty():
-            sys.stderr.write("\r\033[K")
-            sys.stderr.flush()
-        print(f"{Colors.WARNING}⚠️  Cancelled.{Colors.ENDC}")
+    if not _get_interactive_restart_confirmation():
         return False
+
+    # Prepare environment for the new process
+    # Pass the current token to avoid re-prompting if it was entered interactively
+    if TOKEN:
+        os.environ["TOKEN"] = TOKEN
+
+    # Construct command arguments
+    # Use sys.argv filtering to preserve all user-provided flags (even future ones)
+    # while removing --dry-run to switch to live mode.
+    clean_argv = [arg for arg in sys.argv[1:] if arg != "--dry-run"]
+    new_argv = [sys.executable, sys.argv[0]] + clean_argv
+
+    # If --profiles wasn't in original args (meaning it came from env/input),
+    # inject it explicitly so the user doesn't have to re-enter it.
+    if "--profiles" not in sys.argv and profile_ids:
+        new_argv.extend(["--profiles", ",".join(profile_ids)])
+
+    print(f"\n{Colors.GREEN}🔄 Restarting in live mode...{Colors.ENDC}")
+    # Modifying sys.argv in-place allows the main loop to pick up the new arguments
+    # without invoking os.execv, eliminating command injection risks entirely.
+    sys.argv.clear()
+    sys.argv.extend(new_argv)
+    return True
 
 
 def print_line(left_char: str, mid_char: str, right_char: str, w: list[int]) -> str:


### PR DESCRIPTION
💡 What: Added ANSI clear-line sequence (`\r\033[K`) before printing the "cancelled" messages on `KeyboardInterrupt`.
🎯 Why: To prevent the `^C` keystroke residue from remaining on the terminal line and breaking the visual flow when users abort prompts.
📸 Before/After: Before, cancelling left a visible `^C` before the error message; now it cleanly replaces the line.
♿ Accessibility: Clean terminal output without garbage characters helps screen readers parse terminal state changes more accurately.

---
*PR created automatically by Jules for task [8822091522580301060](https://jules.google.com/task/8822091522580301060) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/ctrld-sync/pull/956" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->