### PR TITLE
🎨 Palette: Fix CLI table alignment for emojis

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -69,3 +69,6 @@
 ## 2025-03-03 - CLI Plan Details Alignment Fix
 **Learning:** Python's standard `len()` and format alignment (`:<`) calculate widths by raw character count, causing visual misalignment in CLI tables when strings contain emojis or full-width characters (which take 2 visual columns but count as 1).
 **Action:** When printing structured CLI output like dry-run plan details, use a custom display width calculation (like `_display_len` via `unicodedata`) and custom padding logic (like `_pad_string`) instead of relying on standard f-string formatting.
+## 2024-06-29 - CLI Table Alignment with Emojis
+**Learning:** Standard Python `len()` calculates string length based on character count, which treats emojis (like ✅, ⛔, 🧪) as 1 character. However, terminal emulators render these specific symbols as 2 columns wide. If strings with emojis are padded using `len()`, the table borders will misalign. Using `unicodedata.east_asian_width` helps, but many emojis return `N` (Neutral) or `A` (Ambiguous) for east asian width while still being rendered as 2 columns by the terminal.
+**Action:** When building custom CLI tables that pad text containing emojis, calculate the display width manually by extending the width check to include `So` (Symbol, Other) or `Sk` (Symbol, Modifier) unicode categories with a codepoint > 0x2000.

--- a/main.py
+++ b/main.py
@@ -2728,7 +2728,12 @@ def _display_len(s: str) -> int:
     stripped = _ANSI_ESCAPE_PATTERN.sub("", s)
     # OPTIMIZATION: C-speed list comprehension avoids Python loop overhead
     return len(stripped) + len(
-        [1 for c in stripped if unicodedata.east_asian_width(c) in ("W", "F")]
+        [
+            1
+            for c in stripped
+            if unicodedata.east_asian_width(c) in ("W", "F")
+            or (ord(c) >= 0x2600 and unicodedata.category(c) in ("So", "Sk"))
+        ]
     )
 
 


### PR DESCRIPTION
💡 What: Fixed an issue where CLI tables misaligned when containing emojis (like ✅ and 🧪).
🎯 Why: Emojis render as two terminal columns but standard string length calculates them as 1, breaking table borders. We updated `_display_len` to correctly calculate display width for these characters, using the `So` and `Sk` categories but strictly above `0x2600` so we don't break Box Drawing Characters which are also `So` but < `0x2600`.
📸 Before/After: Terminal output will now have aligned borders.
♿ Accessibility: N/A, visual polish.

---
*PR created automatically by Jules for task [18124789319127999946](https://jules.google.com/task/18124789319127999946) started by @abhimehro*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/ctrld-sync/pull/960" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->