### PR TITLE
🎨 Palette: Guard ANSI escape sequences for CI environments

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -77,3 +77,7 @@
 
 **Learning:** When handling `KeyboardInterrupt` or `EOFError` during long operations, explicitly clearing the terminal line using ANSI sequences (`\r\033[K`) without checking if the environment is a TTY (`sys.stderr.isatty()`) leaks visible ANSI garbage into non-interactive execution logs (like CI or piped output).
 **Action:** Always guard terminal clearance codes and carriage returns with a `sys.stderr.isatty()` check, even if global color settings (`USE_COLORS`) are theoretically supposed to cover it, as `USE_COLORS` might be overridden or misused in edge cases.
+## 2025-05-18 - [ANSI Escape Sequences in CI Environments]
+
+**Learning:** When using ANSI escape sequences to clear lines and show terminal progress (like `\r\033[K`), those escape sequences often leak as raw garbage text when the program's output is not directed to a TTY (like in a CI/CD environment or when piped to a log file).
+**Action:** Always guard terminal clearance codes (e.g., `\r\033[K`) with a `sys.stderr.isatty()` check. If not a TTY, degrade gracefully by appending simple newlines instead of carriage returns.

--- a/main.py
+++ b/main.py
@@ -2179,6 +2179,55 @@ def _push_single_batch(
         return None
 
 
+def _push_batches_parallel(
+    ctx: SyncContext,
+    batches: list[list[str]],
+    sanitized_folder_name: str,
+    str_do: str,
+    str_status: str,
+    str_group: str,
+    progress_label: str,
+    total_batches: int,
+) -> int:
+    successful_batches = 0
+    # Use provided executor or create a local one (fallback)
+    if ctx.batch_executor:
+        executor_ctx: contextlib.AbstractContextManager[concurrent.futures.Executor] = (
+            contextlib.nullcontext(ctx.batch_executor)
+        )
+    else:
+        executor_ctx = concurrent.futures.ThreadPoolExecutor(max_workers=3)
+
+    with executor_ctx as executor:
+        futures = {
+            executor.submit(
+                _push_single_batch,
+                ctx.client,
+                ctx.profile_id,
+                sanitized_folder_name,
+                str_do,
+                str_status,
+                str_group,
+                i,
+                batch,
+            ): i
+            for i, batch in enumerate(batches, 1)
+        }
+
+        for future in concurrent.futures.as_completed(futures):
+            result = future.result()
+            if result:
+                successful_batches += 1
+                ctx.existing_rules.update(result)
+
+            render_progress_bar(
+                successful_batches,
+                total_batches,
+                progress_label,
+            )
+    return successful_batches
+
+
 def _push_rule_batches(
     ctx: SyncContext,
     folder_name: str,
@@ -2225,41 +2274,16 @@ def _push_rule_batches(
             progress_label,
         )
     else:
-        # Use provided executor or create a local one (fallback)
-        if ctx.batch_executor:
-            executor_ctx: contextlib.AbstractContextManager[
-                concurrent.futures.Executor
-            ] = contextlib.nullcontext(ctx.batch_executor)
-        else:
-            executor_ctx = concurrent.futures.ThreadPoolExecutor(max_workers=3)
-
-        with executor_ctx as executor:
-            futures = {
-                executor.submit(
-                    _push_single_batch,
-                    ctx.client,
-                    ctx.profile_id,
-                    sanitized_folder_name,
-                    str_do,
-                    str_status,
-                    str_group,
-                    i,
-                    batch,
-                ): i
-                for i, batch in enumerate(batches, 1)
-            }
-
-            for future in concurrent.futures.as_completed(futures):
-                result = future.result()
-                if result:
-                    successful_batches += 1
-                    ctx.existing_rules.update(result)
-
-                render_progress_bar(
-                    successful_batches,
-                    total_batches,
-                    progress_label,
-                )
+        successful_batches += _push_batches_parallel(
+            ctx,
+            batches,
+            sanitized_folder_name,
+            str_do,
+            str_status,
+            str_group,
+            progress_label,
+            total_batches,
+        )
 
     if successful_batches == total_batches:
         if USE_COLORS:

--- a/main.py
+++ b/main.py
@@ -693,13 +693,15 @@ def countdown_timer(seconds: int, message: str = "Waiting") -> None:
         progress = (seconds - remaining + 1) / seconds
         filled = int(width * progress)
         bar = "█" * filled + "·" * (width - filled)
+        clear_prefix = "\r\033[K" if sys.stderr.isatty() else "\n"
         sys.stderr.write(
-            f"\r\033[K{Colors.CYAN}⏳ {message}: [{bar}] {remaining:>{max_len}}s...{Colors.ENDC}"
+            f"{clear_prefix}{Colors.CYAN}⏳ {message}: [{bar}] {remaining:>{max_len}}s...{Colors.ENDC}"
         )
         sys.stderr.flush()
         time.sleep(1)
 
-    sys.stderr.write(f"\r\033[K{Colors.GREEN}✅ {message}: Done!{Colors.ENDC}\n")
+    clear_prefix = "\r\033[K" if sys.stderr.isatty() else "\n"
+    sys.stderr.write(f"{clear_prefix}{Colors.GREEN}✅ {message}: Done!{Colors.ENDC}\n")
     sys.stderr.flush()
 
 
@@ -720,8 +722,9 @@ def render_progress_bar(
     total_str = str(total)
 
     # Use \033[K to clear line residue
+    clear_prefix = "\r\033[K" if sys.stderr.isatty() else "\n"
     sys.stderr.write(
-        f"\r\033[K{Colors.CYAN}{prefix} {label}: [{bar}] {percent:>3}% ({current:>{len(total_str)}}/{total_str}){Colors.ENDC}"
+        f"{clear_prefix}{Colors.CYAN}{prefix} {label}: [{bar}] {percent:>3}% ({current:>{len(total_str)}}/{total_str}){Colors.ENDC}"
     )
     sys.stderr.flush()
 
@@ -1907,8 +1910,8 @@ def warm_up_cache(urls: Sequence[str]) -> None:
             try:
                 future.result()
             except Exception as e:
-                if USE_COLORS:
-                    # Clear line to print warning cleanly
+                # Clear line to print warning cleanly
+                if USE_COLORS and sys.stderr.isatty():
                     sys.stderr.write("\r\033[K")
                     sys.stderr.flush()
 
@@ -1920,8 +1923,9 @@ def warm_up_cache(urls: Sequence[str]) -> None:
                 render_progress_bar(completed, total, "Warming up cache", prefix="⏳")
 
     if USE_COLORS:
+        clear_prefix = "\r\033[K" if sys.stderr.isatty() else "\n"
         sys.stderr.write(
-            f"\r\033[K{Colors.GREEN}✅ Warming up cache: Done!{Colors.ENDC}\n"
+            f"{clear_prefix}{Colors.GREEN}✅ Warming up cache: Done!{Colors.ENDC}\n"
         )
         sys.stderr.flush()
     else:
@@ -2155,7 +2159,7 @@ def _push_single_batch(
             )
         return batch_data
     except httpx.HTTPError as e:
-        if USE_COLORS:
+        if USE_COLORS and sys.stderr.isatty():
             sys.stderr.write("\r\033[K")
             sys.stderr.flush()
         hint = ""
@@ -2259,8 +2263,9 @@ def _push_rule_batches(
 
     if successful_batches == total_batches:
         if USE_COLORS:
+            clear_prefix = "\r\033[K" if sys.stderr.isatty() else "\n"
             sys.stderr.write(
-                f"\r\033[K{Colors.GREEN}✅ Folder {sanitized_folder_name}: Finished ({len(filtered_hostnames):,} {pluralize(len(filtered_hostnames), 'rule')}){Colors.ENDC}\n"
+                f"{clear_prefix}{Colors.GREEN}✅ Folder {sanitized_folder_name}: Finished ({len(filtered_hostnames):,} {pluralize(len(filtered_hostnames), 'rule')}){Colors.ENDC}\n"
             )
             sys.stderr.flush()
         else:
@@ -2268,7 +2273,7 @@ def _push_rule_batches(
                 f"✅ Folder {sanitized_folder_name} – finished ({len(filtered_hostnames):,} new {pluralize(len(filtered_hostnames), 'rule')} added)"
             )
         return True
-    if USE_COLORS:
+    if USE_COLORS and sys.stderr.isatty():
         sys.stderr.write("\r\033[K")
         sys.stderr.flush()
     log.error(

--- a/tests/test_ux.py
+++ b/tests/test_ux.py
@@ -218,7 +218,8 @@ class TestRenderProgressBar:
         err = capsys.readouterr().err
         assert "Loading" in err
         assert "█" in err
-        assert "\r\033[K" in err
+        # Since capsys is not a tty, we get a newline instead
+        assert "\n" in err
 
 
 class TestMakeColSeparator:


### PR DESCRIPTION
💡 What: Guarded \r\033[K terminal clearance codes with sys.stderr.isatty().
🎯 Why: Using terminal clearance codes without checking if the environment is a TTY leaks visible ANSI garbage into non-interactive execution logs (like CI or piped output). 
♿ Accessibility: N/A

===== ELIR =====
PURPOSE: Wrap terminal escape sequences with a TTY check to prevent ANSI garbage in CI logs.
SECURITY: N/A
FAILS IF: Non-TTY environment does not handle escape codes properly.
VERIFY: Run the script and check output behavior in a non-interactive environment.
MAINTAIN: Be sure to check sys.stderr.isatty() before outputting raw ANSI escape sequences like \r\033[K.

---
*PR created automatically by Jules for task [17874825928557670458](https://jules.google.com/task/17874825928557670458) started by @abhimehro*