### PR TITLE
fix(ux): guard ANSI progress output with stderr.isatty() (salvages #965)

### DIFF
--- a/main.py
+++ b/main.py
@@ -707,7 +707,11 @@ def render_progress_bar(
     current: int, total: int, label: str, prefix: str = "🚀"
 ) -> None:
     """Renders a progress bar to stderr if USE_COLORS is True."""
-    if not USE_COLORS or not sys.stderr.isatty() or total == 0:
+    if not USE_COLORS:
+        return
+    if not sys.stderr.isatty():
+        return
+    if total == 0:
         return
 
     width = _get_progress_bar_width()

--- a/main.py
+++ b/main.py
@@ -668,24 +668,17 @@ def countdown_timer(seconds: int, message: str = "Waiting") -> None:
     mode, sleep silently for short waits and log periodic heartbeat messages
     for longer waits."""
     if not USE_COLORS or not sys.stderr.isatty():
-        # UX Improvement: For long waits in non-interactive/no-color mode (e.g. CI),
-        # log periodic updates instead of sleeping silently.
+        # Non-interactive countdown
         if seconds > 10:
-            step = 10
-            for remaining in range(seconds, 0, -step):
+            for remaining in range(seconds, 0, -10):
                 # Don't log the first one if we already logged "Waiting..." before calling this
                 if remaining < seconds:
                     log.info(f"{sanitize_for_log(message)}: {remaining}s remaining...")
-
-                sleep_time = min(step, remaining)
-                time.sleep(sleep_time)
-            log.info(f"✅ {sanitize_for_log(message)}: Done!")
-            return
-
-        time.sleep(seconds)
+                time.sleep(min(10, remaining))
+        else:
+            time.sleep(seconds)
         log.info(f"✅ {sanitize_for_log(message)}: Done!")
         return
-
     width = _get_progress_bar_width()
     max_len = len(str(seconds))
 
@@ -713,7 +706,6 @@ def render_progress_bar(
         return
     if total == 0:
         return
-
     width = _get_progress_bar_width()
 
     progress = min(1.0, current / total)
@@ -2717,11 +2709,6 @@ def prompt_for_interactive_restart(profile_ids: list[str]) -> bool:
     return True
 
 
-def print_line(left_char: str, mid_char: str, right_char: str, w: list[int]) -> str:
-    """Format a horizontal table separator line."""
-    return f"{Colors.BOLD}{left_char}{mid_char.join('─' * (x + 2) for x in w)}{right_char}{Colors.ENDC}"
-
-
 _ANSI_ESCAPE_PATTERN = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
 
 
@@ -2755,6 +2742,11 @@ def _pad_string(s: str, width: int, align: str = "<") -> str:
         right = pad_len - left
         return " " * left + s + " " * right
     return s
+
+
+def print_line(left_char: str, mid_char: str, right_char: str, w: list[int]) -> str:
+    """Format a horizontal table separator line."""
+    return f"{Colors.BOLD}{left_char}{mid_char.join('─' * (x + 2) for x in w)}{right_char}{Colors.ENDC}"
 
 
 def print_row(cols: list[str], w: list[int]) -> str:

--- a/main.py
+++ b/main.py
@@ -667,7 +667,7 @@ def countdown_timer(seconds: int, message: str = "Waiting") -> None:
     """Show a countdown in interactive/color mode; in no-color/non-interactive
     mode, sleep silently for short waits and log periodic heartbeat messages
     for longer waits."""
-    if not USE_COLORS:
+    if not USE_COLORS or not sys.stderr.isatty():
         # UX Improvement: For long waits in non-interactive/no-color mode (e.g. CI),
         # log periodic updates instead of sleeping silently.
         if seconds > 10:
@@ -707,7 +707,7 @@ def render_progress_bar(
     current: int, total: int, label: str, prefix: str = "🚀"
 ) -> None:
     """Renders a progress bar to stderr if USE_COLORS is True."""
-    if not USE_COLORS or total == 0:
+    if not USE_COLORS or not sys.stderr.isatty() or total == 0:
         return
 
     width = _get_progress_bar_width()

--- a/tests/test_ux.py
+++ b/tests/test_ux.py
@@ -14,6 +14,7 @@ def test_countdown_timer_visuals(monkeypatch):
 
     # Mock stderr
     mock_stderr = MagicMock()
+    mock_stderr.isatty.return_value = True
     monkeypatch.setattr(sys, "stderr", mock_stderr)
 
     # Mock time.sleep to run instantly
@@ -40,6 +41,7 @@ def test_countdown_timer_no_colors_short(monkeypatch):
     """Verify that short countdowns sleep silently without writing to stderr if NO_COLOR."""
     monkeypatch.setattr(main, "USE_COLORS", False)
     mock_stderr = MagicMock()
+    mock_stderr.isatty.return_value = False
     monkeypatch.setattr(sys, "stderr", mock_stderr)
     mock_sleep = MagicMock()
     monkeypatch.setattr(main.time, "sleep", mock_sleep)
@@ -214,11 +216,40 @@ class TestRenderProgressBar:
             "get_terminal_size",
             lambda fallback=(80, 24): os.terminal_size((80, 24)),
         )
+
+        class DummyStderr:
+            def __init__(self):
+                self.out: list[str] = []
+
+            def write(self, text: str) -> None:
+                self.out.append(text)
+
+            def flush(self) -> None:
+                pass
+
+            def isatty(self) -> bool:
+                return True
+
+        dummy = DummyStderr()
+        monkeypatch.setattr(main.sys, "stderr", dummy)
+
         main.render_progress_bar(5, 10, "Loading")
-        err = capsys.readouterr().err
+        err = "".join(dummy.out)
         assert "Loading" in err
         assert "█" in err
         assert "\r\033[K" in err
+
+    def test_no_output_when_stderr_not_tty(self, monkeypatch, capsys):
+        """render_progress_bar skips ANSI output when stderr is not a TTY."""
+        monkeypatch.setattr(main, "USE_COLORS", True)
+
+        class DummyStderr:
+            def isatty(self) -> bool:
+                return False
+
+        monkeypatch.setattr(main.sys, "stderr", DummyStderr())
+        main.render_progress_bar(5, 10, "Loading")
+        assert capsys.readouterr().err == ""
 
 
 class TestMakeColSeparator:


### PR DESCRIPTION
Salvage of [#965](https://github.com/abhimehro/ctrld-sync/pull/965) onto current `main`.

## What changed
- `countdown_timer`: skip ANSI progress bar when `stderr` is not a TTY
- `render_progress_bar`: same guard (prevents `\r\033[K` garbage in CI/piped logs)
- Tests: mock `stderr.isatty()` in progress-bar tests; add non-TTY skip test

## Why file-scoped salvage
Original #965 was DIRTY (412-line conflict in `main.py` from unrelated refactors). Only the isatty UX guards were salvaged.

**Tier:** T3 — routine UX salvage

## Verification
```bash
uv run pytest tests/test_ux.py -q
uv run python -m py_compile main.py
```

═══ ELIR ═══
PURPOSE: Prevent ANSI escape sequences leaking into non-interactive logs while preserving interactive progress UI.
SECURITY: No auth/secrets touched; display-layer hardening only.
FAILS IF: `isatty()` mocked incorrectly in tests or TTY detection regresses on real terminals.
VERIFY: Run `uv run pytest tests/test_ux.py -q` and spot-check dry-run in CI vs local TTY.
MAINTAIN: Any new stderr progress/ANSI output should follow the same `USE_COLORS and sys.stderr.isatty()` pattern.

Refs: #965 (salvage source)