### PR TITLE
🎨 Palette: Clean up terminal residue and extraneous newlines in CLI

### DIFF
--- a/main.py
+++ b/main.py
@@ -2257,17 +2257,34 @@ def _push_rule_batches(
                     progress_label,
                 )
 
+    _log_batch_results(
+        successful_batches,
+        total_batches,
+        sanitized_folder_name,
+        len(filtered_hostnames),
+    )
+
+    return successful_batches == total_batches
+
+
+def _log_batch_results(
+    successful_batches: int,
+    total_batches: int,
+    sanitized_folder_name: str,
+    num_rules: int,
+) -> None:
     if successful_batches == total_batches:
         if USE_COLORS and sys.stderr.isatty():
             sys.stderr.write(
-                f"\r\033[K{Colors.GREEN}✅ Folder {sanitized_folder_name}: Finished ({len(filtered_hostnames):,} {pluralize(len(filtered_hostnames), 'rule')}){Colors.ENDC}\n"
+                f"\r\033[K{Colors.GREEN}✅ Folder {sanitized_folder_name}: Finished ({num_rules:,} {pluralize(num_rules, 'rule')}){Colors.ENDC}\n"
             )
             sys.stderr.flush()
         else:
             log.info(
-                f"✅ Folder {sanitized_folder_name} – finished ({len(filtered_hostnames):,} new {pluralize(len(filtered_hostnames), 'rule')} added)"
+                f"✅ Folder {sanitized_folder_name} – finished ({num_rules:,} new {pluralize(num_rules, 'rule')} added)"
             )
-        return True
+        return
+
     if USE_COLORS and sys.stderr.isatty():
         sys.stderr.write("\r\033[K")
         sys.stderr.flush()
@@ -2277,7 +2294,6 @@ def _push_rule_batches(
         successful_batches,
         total_batches,
     )
-    return False
 
 
 def push_rules(

--- a/main.py
+++ b/main.py
@@ -667,7 +667,7 @@ def countdown_timer(seconds: int, message: str = "Waiting") -> None:
     """Show a countdown in interactive/color mode; in no-color/non-interactive
     mode, sleep silently for short waits and log periodic heartbeat messages
     for longer waits."""
-    if not USE_COLORS:
+    if not USE_COLORS or not sys.stderr.isatty():
         # UX Improvement: For long waits in non-interactive/no-color mode (e.g. CI),
         # log periodic updates instead of sleeping silently.
         if seconds > 10:
@@ -707,7 +707,7 @@ def render_progress_bar(
     current: int, total: int, label: str, prefix: str = "🚀"
 ) -> None:
     """Renders a progress bar to stderr if USE_COLORS is True."""
-    if not USE_COLORS or total == 0:
+    if not USE_COLORS or not sys.stderr.isatty() or total == 0:
         return
 
     width = _get_progress_bar_width()
@@ -1907,7 +1907,7 @@ def warm_up_cache(urls: Sequence[str]) -> None:
             try:
                 future.result()
             except Exception as e:
-                if USE_COLORS:
+                if USE_COLORS and sys.stderr.isatty():
                     # Clear line to print warning cleanly
                     sys.stderr.write("\r\033[K")
                     sys.stderr.flush()
@@ -1919,7 +1919,7 @@ def warm_up_cache(urls: Sequence[str]) -> None:
                 # Restore progress bar after warning
                 render_progress_bar(completed, total, "Warming up cache", prefix="⏳")
 
-    if USE_COLORS:
+    if USE_COLORS and sys.stderr.isatty():
         sys.stderr.write(
             f"\r\033[K{Colors.GREEN}✅ Warming up cache: Done!{Colors.ENDC}\n"
         )
@@ -2155,7 +2155,7 @@ def _push_single_batch(
             )
         return batch_data
     except httpx.HTTPError as e:
-        if USE_COLORS:
+        if USE_COLORS and sys.stderr.isatty():
             sys.stderr.write("\r\033[K")
             sys.stderr.flush()
         hint = ""
@@ -2258,7 +2258,7 @@ def _push_rule_batches(
                 )
 
     if successful_batches == total_batches:
-        if USE_COLORS:
+        if USE_COLORS and sys.stderr.isatty():
             sys.stderr.write(
                 f"\r\033[K{Colors.GREEN}✅ Folder {sanitized_folder_name}: Finished ({len(filtered_hostnames):,} {pluralize(len(filtered_hostnames), 'rule')}){Colors.ENDC}\n"
             )
@@ -2268,7 +2268,7 @@ def _push_rule_batches(
                 f"✅ Folder {sanitized_folder_name} – finished ({len(filtered_hostnames):,} new {pluralize(len(filtered_hostnames), 'rule')} added)"
             )
         return True
-    if USE_COLORS:
+    if USE_COLORS and sys.stderr.isatty():
         sys.stderr.write("\r\033[K")
         sys.stderr.flush()
     log.error(
@@ -2645,7 +2645,7 @@ def _get_interactive_restart_confirmation() -> bool:
     """Helper to prompt for and validate interactive restart confirmation."""
     prompt_initial = f"\n{Colors.BOLD}🚀 Ready to launch? {Colors.ENDC}Press [Enter] to run now (or type 'n' / Ctrl+C to cancel)... "
     prompt_reprompt = f"{Colors.BOLD}🚀 Ready to launch? {Colors.ENDC}Press [Enter] to run now (or type 'n' / Ctrl+C to cancel)... "
-    cancel_msg = f"\n{Colors.WARNING}⚠️  Cancelled.{Colors.ENDC}"
+    cancel_msg = f"{Colors.WARNING}⚠️  Cancelled.{Colors.ENDC}"
     err_msg = f"{Colors.FAIL}❌ Unrecognized input. Please press Enter to continue, or 'n' to cancel.{Colors.ENDC}"
 
     prompt = prompt_initial
@@ -2660,7 +2660,7 @@ def _get_interactive_restart_confirmation() -> bool:
             if sys.stderr.isatty():
                 sys.stderr.write("\r\033[K")
                 sys.stderr.flush()
-            print(cancel_msg.lstrip("\n"))
+            print(cancel_msg)
             return False
 
         if user_response in ("", "y", "yes"):
@@ -3229,11 +3229,11 @@ def main() -> bool:
             )
     except KeyboardInterrupt:
         duration = time.time() - start_time
-        if USE_COLORS and sys.stderr.isatty():
+        if sys.stderr.isatty():
             sys.stderr.write("\r\033[K")
             sys.stderr.flush()
         print(
-            f"\n{Colors.WARNING}⚠️  Sync cancelled by user. Finishing current task...{Colors.ENDC}"
+            f"{Colors.WARNING}⚠️  Sync cancelled by user. Finishing current task...{Colors.ENDC}"
         )
 
         # Try to recover stats for the interrupted profile

--- a/main.py
+++ b/main.py
@@ -707,11 +707,7 @@ def render_progress_bar(
     current: int, total: int, label: str, prefix: str = "🚀"
 ) -> None:
     """Renders a progress bar to stderr if USE_COLORS is True."""
-    if total == 0:
-        return
-    if not USE_COLORS:
-        return
-    if not sys.stderr.isatty():
+    if not USE_COLORS or not sys.stderr.isatty() or total == 0:
         return
 
     width = _get_progress_bar_width()
@@ -1882,7 +1878,7 @@ def warm_up_cache(urls: Sequence[str]) -> None:
     """
     urls = list(set(urls))
     with _cache_lock:
-        urls_to_process = list(set(urls) - _cache.keys())
+        urls_to_process = [u for u in urls if u not in _cache]
     if not urls_to_process:
         return
 
@@ -1890,9 +1886,13 @@ def warm_up_cache(urls: Sequence[str]) -> None:
     if not USE_COLORS:
         log.info(f"⏳ Warming up cache for {total:,} {pluralize(total, 'URL')}...")
 
-    _validate_and_fetch = lambda url: _gh_get(url) if validate_folder_url(url) else None
+    # OPTIMIZATION: Combine validation (DNS) and fetching (HTTP) in one task
+    # to allow validation latency to be parallelized.
+    def _validate_and_fetch(url: str):
+        if validate_folder_url(url):
+            return _gh_get(url)
+        return None
 
-    is_tty = bool(USE_COLORS and sys.stderr.isatty())
     completed = 0
     with concurrent.futures.ThreadPoolExecutor() as executor:
         futures = {
@@ -1907,7 +1907,7 @@ def warm_up_cache(urls: Sequence[str]) -> None:
             try:
                 future.result()
             except Exception as e:
-                if is_tty:
+                if USE_COLORS and sys.stderr.isatty():
                     # Clear line to print warning cleanly
                     sys.stderr.write("\r\033[K")
                     sys.stderr.flush()
@@ -1919,7 +1919,7 @@ def warm_up_cache(urls: Sequence[str]) -> None:
                 # Restore progress bar after warning
                 render_progress_bar(completed, total, "Warming up cache", prefix="⏳")
 
-    if is_tty:
+    if USE_COLORS and sys.stderr.isatty():
         sys.stderr.write(
             f"\r\033[K{Colors.GREEN}✅ Warming up cache: Done!{Colors.ENDC}\n"
         )
@@ -2143,7 +2143,6 @@ def _push_single_batch(
     # strict=False is intentional: batch_data may be shorter than BATCH_KEYS for final batch
     data.update(zip(BATCH_KEYS, batch_data, strict=False))
 
-    is_tty = bool(USE_COLORS and sys.stderr.isatty())
     try:
         _api_post_form(client, f"{API_BASE}/{profile_id}/rules", data=data)
         if not USE_COLORS:
@@ -2156,21 +2155,23 @@ def _push_single_batch(
             )
         return batch_data
     except httpx.HTTPError as e:
-        if is_tty:
+        if USE_COLORS and sys.stderr.isatty():
             sys.stderr.write("\r\033[K")
             sys.stderr.flush()
-        
         hint = ""
-        response = getattr(e, "response", None)
-        if response is not None:
-            status_code = response.status_code
+        if isinstance(e, httpx.HTTPStatusError):
+            # Use a more specific name to avoid confusion with the rule "status" payload
+            status_code = e.response.status_code
             hint = f" ({_STATUS_HINTS.get(status_code, f'HTTP {status_code}')})"
-            
         log.error(
             f"Failed to push batch {batch_idx} for folder {sanitized_folder_name}{hint}: {sanitize_for_log(e)}"
         )
-        if response is not None and log.isEnabledFor(logging.DEBUG):
-            log.debug(f"Response content: {sanitize_for_log(response.text)}")
+        if (
+            hasattr(e, "response")
+            and e.response is not None
+            and log.isEnabledFor(logging.DEBUG)
+        ):
+            log.debug(f"Response content: {sanitize_for_log(e.response.text)}")
         return None
 
 
@@ -2199,69 +2200,84 @@ def _push_rule_batches(
     progress_label = f"Folder {sanitized_folder_name}"
 
     # Optimization 3: Parallelize batch processing
-    if ctx.batch_executor:
-        executor_ctx: contextlib.AbstractContextManager[
-            concurrent.futures.Executor
-        ] = contextlib.nullcontext(ctx.batch_executor)
-    else:
-        executor_ctx = concurrent.futures.ThreadPoolExecutor(max_workers=3)
-
-    with executor_ctx as executor:
-        futures = {
-            executor.submit(
-                _push_single_batch,
-                ctx.client,
-                ctx.profile_id,
-                sanitized_folder_name,
-                str_do,
-                str_status,
-                str_group,
-                i,
-                batch,
-            ): i
-            for i, batch in enumerate(batches, 1)
-        }
-
-        for future in concurrent.futures.as_completed(futures):
-            result = future.result()
-            if result:
-                successful_batches += 1
-                ctx.existing_rules.update(result)
-
-            render_progress_bar(
-                successful_batches,
-                total_batches,
-                progress_label,
-            )
-
-    def _log_results() -> None:
-        is_tty = bool(USE_COLORS and sys.stderr.isatty())
-        if successful_batches == total_batches:
-            num_rules = len(filtered_hostnames)
-            if is_tty:
-                sys.stderr.write(
-                    f"\r\033[K{Colors.GREEN}✅ Folder {sanitized_folder_name}: Finished ({num_rules:,} {pluralize(num_rules, 'rule')}){Colors.ENDC}\n"
-                )
-                sys.stderr.flush()
-            else:
-                log.info(
-                    f"✅ Folder {sanitized_folder_name} – finished ({num_rules:,} new {pluralize(num_rules, 'rule')} added)"
-                )
-            return
-
-        if is_tty:
-            sys.stderr.write("\r\033[K")
-            sys.stderr.flush()
-        log.error(
-            "Folder %s – only %d/%d batches succeeded",
+    if total_batches == 1:
+        result = _push_single_batch(
+            ctx.client,
+            ctx.profile_id,
             sanitized_folder_name,
+            str_do,
+            str_status,
+            str_group,
+            1,
+            batches[0],
+        )
+        if result:
+            successful_batches += 1
+            ctx.existing_rules.update(result)
+
+        render_progress_bar(
             successful_batches,
             total_batches,
+            progress_label,
         )
+    else:
+        # Use provided executor or create a local one (fallback)
+        if ctx.batch_executor:
+            executor_ctx: contextlib.AbstractContextManager[
+                concurrent.futures.Executor
+            ] = contextlib.nullcontext(ctx.batch_executor)
+        else:
+            executor_ctx = concurrent.futures.ThreadPoolExecutor(max_workers=3)
 
-    _log_results()
+        with executor_ctx as executor:
+            futures = {
+                executor.submit(
+                    _push_single_batch,
+                    ctx.client,
+                    ctx.profile_id,
+                    sanitized_folder_name,
+                    str_do,
+                    str_status,
+                    str_group,
+                    i,
+                    batch,
+                ): i
+                for i, batch in enumerate(batches, 1)
+            }
 
-    return successful_batches == total_batches
+            for future in concurrent.futures.as_completed(futures):
+                result = future.result()
+                if result:
+                    successful_batches += 1
+                    ctx.existing_rules.update(result)
+
+                render_progress_bar(
+                    successful_batches,
+                    total_batches,
+                    progress_label,
+                )
+
+    if successful_batches == total_batches:
+        if USE_COLORS and sys.stderr.isatty():
+            sys.stderr.write(
+                f"\r\033[K{Colors.GREEN}✅ Folder {sanitized_folder_name}: Finished ({len(filtered_hostnames):,} {pluralize(len(filtered_hostnames), 'rule')}){Colors.ENDC}\n"
+            )
+            sys.stderr.flush()
+        else:
+            log.info(
+                f"✅ Folder {sanitized_folder_name} – finished ({len(filtered_hostnames):,} new {pluralize(len(filtered_hostnames), 'rule')} added)"
+            )
+        return True
+    if USE_COLORS and sys.stderr.isatty():
+        sys.stderr.write("\r\033[K")
+        sys.stderr.flush()
+    log.error(
+        "Folder %s – only %d/%d batches succeeded",
+        sanitized_folder_name,
+        successful_batches,
+        total_batches,
+    )
+    return False
 
 
 def push_rules(

--- a/main.py
+++ b/main.py
@@ -707,7 +707,11 @@ def render_progress_bar(
     current: int, total: int, label: str, prefix: str = "🚀"
 ) -> None:
     """Renders a progress bar to stderr if USE_COLORS is True."""
-    if not USE_COLORS or not sys.stderr.isatty() or total == 0:
+    if total == 0:
+        return
+    if not USE_COLORS:
+        return
+    if not sys.stderr.isatty():
         return
 
     width = _get_progress_bar_width()
@@ -1878,7 +1882,7 @@ def warm_up_cache(urls: Sequence[str]) -> None:
     """
     urls = list(set(urls))
     with _cache_lock:
-        urls_to_process = [u for u in urls if u not in _cache]
+        urls_to_process = list(set(urls) - _cache.keys())
     if not urls_to_process:
         return
 
@@ -1886,13 +1890,9 @@ def warm_up_cache(urls: Sequence[str]) -> None:
     if not USE_COLORS:
         log.info(f"⏳ Warming up cache for {total:,} {pluralize(total, 'URL')}...")
 
-    # OPTIMIZATION: Combine validation (DNS) and fetching (HTTP) in one task
-    # to allow validation latency to be parallelized.
-    def _validate_and_fetch(url: str):
-        if validate_folder_url(url):
-            return _gh_get(url)
-        return None
+    _validate_and_fetch = lambda url: _gh_get(url) if validate_folder_url(url) else None
 
+    is_tty = bool(USE_COLORS and sys.stderr.isatty())
     completed = 0
     with concurrent.futures.ThreadPoolExecutor() as executor:
         futures = {
@@ -1907,7 +1907,7 @@ def warm_up_cache(urls: Sequence[str]) -> None:
             try:
                 future.result()
             except Exception as e:
-                if USE_COLORS and sys.stderr.isatty():
+                if is_tty:
                     # Clear line to print warning cleanly
                     sys.stderr.write("\r\033[K")
                     sys.stderr.flush()
@@ -1919,7 +1919,7 @@ def warm_up_cache(urls: Sequence[str]) -> None:
                 # Restore progress bar after warning
                 render_progress_bar(completed, total, "Warming up cache", prefix="⏳")
 
-    if USE_COLORS and sys.stderr.isatty():
+    if is_tty:
         sys.stderr.write(
             f"\r\033[K{Colors.GREEN}✅ Warming up cache: Done!{Colors.ENDC}\n"
         )
@@ -2143,6 +2143,7 @@ def _push_single_batch(
     # strict=False is intentional: batch_data may be shorter than BATCH_KEYS for final batch
     data.update(zip(BATCH_KEYS, batch_data, strict=False))
 
+    is_tty = bool(USE_COLORS and sys.stderr.isatty())
     try:
         _api_post_form(client, f"{API_BASE}/{profile_id}/rules", data=data)
         if not USE_COLORS:
@@ -2155,23 +2156,21 @@ def _push_single_batch(
             )
         return batch_data
     except httpx.HTTPError as e:
-        if USE_COLORS and sys.stderr.isatty():
+        if is_tty:
             sys.stderr.write("\r\033[K")
             sys.stderr.flush()
+        
         hint = ""
-        if isinstance(e, httpx.HTTPStatusError):
-            # Use a more specific name to avoid confusion with the rule "status" payload
-            status_code = e.response.status_code
+        response = getattr(e, "response", None)
+        if response is not None:
+            status_code = response.status_code
             hint = f" ({_STATUS_HINTS.get(status_code, f'HTTP {status_code}')})"
+            
         log.error(
             f"Failed to push batch {batch_idx} for folder {sanitized_folder_name}{hint}: {sanitize_for_log(e)}"
         )
-        if (
-            hasattr(e, "response")
-            and e.response is not None
-            and log.isEnabledFor(logging.DEBUG)
-        ):
-            log.debug(f"Response content: {sanitize_for_log(e.response.text)}")
+        if response is not None and log.isEnabledFor(logging.DEBUG):
+            log.debug(f"Response content: {sanitize_for_log(response.text)}")
         return None
 
 
@@ -2200,100 +2199,69 @@ def _push_rule_batches(
     progress_label = f"Folder {sanitized_folder_name}"
 
     # Optimization 3: Parallelize batch processing
-    if total_batches == 1:
-        result = _push_single_batch(
-            ctx.client,
-            ctx.profile_id,
-            sanitized_folder_name,
-            str_do,
-            str_status,
-            str_group,
-            1,
-            batches[0],
-        )
-        if result:
-            successful_batches += 1
-            ctx.existing_rules.update(result)
+    if ctx.batch_executor:
+        executor_ctx: contextlib.AbstractContextManager[
+            concurrent.futures.Executor
+        ] = contextlib.nullcontext(ctx.batch_executor)
+    else:
+        executor_ctx = concurrent.futures.ThreadPoolExecutor(max_workers=3)
 
-        render_progress_bar(
+    with executor_ctx as executor:
+        futures = {
+            executor.submit(
+                _push_single_batch,
+                ctx.client,
+                ctx.profile_id,
+                sanitized_folder_name,
+                str_do,
+                str_status,
+                str_group,
+                i,
+                batch,
+            ): i
+            for i, batch in enumerate(batches, 1)
+        }
+
+        for future in concurrent.futures.as_completed(futures):
+            result = future.result()
+            if result:
+                successful_batches += 1
+                ctx.existing_rules.update(result)
+
+            render_progress_bar(
+                successful_batches,
+                total_batches,
+                progress_label,
+            )
+
+    def _log_results() -> None:
+        is_tty = bool(USE_COLORS and sys.stderr.isatty())
+        if successful_batches == total_batches:
+            num_rules = len(filtered_hostnames)
+            if is_tty:
+                sys.stderr.write(
+                    f"\r\033[K{Colors.GREEN}✅ Folder {sanitized_folder_name}: Finished ({num_rules:,} {pluralize(num_rules, 'rule')}){Colors.ENDC}\n"
+                )
+                sys.stderr.flush()
+            else:
+                log.info(
+                    f"✅ Folder {sanitized_folder_name} – finished ({num_rules:,} new {pluralize(num_rules, 'rule')} added)"
+                )
+            return
+
+        if is_tty:
+            sys.stderr.write("\r\033[K")
+            sys.stderr.flush()
+        log.error(
+            "Folder %s – only %d/%d batches succeeded",
+            sanitized_folder_name,
             successful_batches,
             total_batches,
-            progress_label,
         )
-    else:
-        # Use provided executor or create a local one (fallback)
-        if ctx.batch_executor:
-            executor_ctx: contextlib.AbstractContextManager[
-                concurrent.futures.Executor
-            ] = contextlib.nullcontext(ctx.batch_executor)
-        else:
-            executor_ctx = concurrent.futures.ThreadPoolExecutor(max_workers=3)
 
-        with executor_ctx as executor:
-            futures = {
-                executor.submit(
-                    _push_single_batch,
-                    ctx.client,
-                    ctx.profile_id,
-                    sanitized_folder_name,
-                    str_do,
-                    str_status,
-                    str_group,
-                    i,
-                    batch,
-                ): i
-                for i, batch in enumerate(batches, 1)
-            }
-
-            for future in concurrent.futures.as_completed(futures):
-                result = future.result()
-                if result:
-                    successful_batches += 1
-                    ctx.existing_rules.update(result)
-
-                render_progress_bar(
-                    successful_batches,
-                    total_batches,
-                    progress_label,
-                )
-
-    _log_batch_results(
-        successful_batches,
-        total_batches,
-        sanitized_folder_name,
-        len(filtered_hostnames),
-    )
+    _log_results()
 
     return successful_batches == total_batches
-
-
-def _log_batch_results(
-    successful_batches: int,
-    total_batches: int,
-    sanitized_folder_name: str,
-    num_rules: int,
-) -> None:
-    if successful_batches == total_batches:
-        if USE_COLORS and sys.stderr.isatty():
-            sys.stderr.write(
-                f"\r\033[K{Colors.GREEN}✅ Folder {sanitized_folder_name}: Finished ({num_rules:,} {pluralize(num_rules, 'rule')}){Colors.ENDC}\n"
-            )
-            sys.stderr.flush()
-        else:
-            log.info(
-                f"✅ Folder {sanitized_folder_name} – finished ({num_rules:,} new {pluralize(num_rules, 'rule')} added)"
-            )
-        return
-
-    if USE_COLORS and sys.stderr.isatty():
-        sys.stderr.write("\r\033[K")
-        sys.stderr.flush()
-    log.error(
-        "Folder %s – only %d/%d batches succeeded",
-        sanitized_folder_name,
-        successful_batches,
-        total_batches,
-    )
 
 
 def push_rules(

--- a/tests/test_ux.py
+++ b/tests/test_ux.py
@@ -209,6 +209,7 @@ class TestRenderProgressBar:
     def test_writes_progress_bar_to_stderr(self, monkeypatch, capsys):
         """render_progress_bar writes a formatted bar to stderr when enabled."""
         monkeypatch.setattr(main, "USE_COLORS", True)
+        monkeypatch.setattr(sys.stderr, "isatty", lambda: True)
         monkeypatch.setattr(
             main.shutil,
             "get_terminal_size",


### PR DESCRIPTION
💡 What: Guarded all terminal clearance sequences (`\r\033[K`) with `sys.stderr.isatty()` checks and removed extraneous newlines from interactive cancellation messages.
🎯 Why: Prevents visible ANSI garbage in CI/piped logs when `USE_COLORS` is forced on, and improves the visual aesthetics of the cancellation UX.
📸 Before/After: Visual alignment and clean logs.
♿ Accessibility: Clean text for non-interactive outputs.

---
*PR created automatically by Jules for task [734424733249333036](https://jules.google.com/task/734424733249333036) started by @abhimehro*