### PR TITLE
🎨 Palette: Remove extraneous blank line on sync cancellation

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -77,3 +77,8 @@
 
 **Learning:** When handling `KeyboardInterrupt` or `EOFError` during long operations, explicitly clearing the terminal line using ANSI sequences (`\r\033[K`) without checking if the environment is a TTY (`sys.stderr.isatty()`) leaks visible ANSI garbage into non-interactive execution logs (like CI or piped output).
 **Action:** Always guard terminal clearance codes and carriage returns with a `sys.stderr.isatty()` check, even if global color settings (`USE_COLORS`) are theoretically supposed to cover it, as `USE_COLORS` might be overridden or misused in edge cases.
+
+## 2025-10-25 - [Extraneous Blank Lines from ^C Cleanup]
+
+**Learning:** When handling `KeyboardInterrupt` or `EOFError` during interactive CLI flows (like prompts or main loops), outputting a cancellation message with a leading newline (`\n`) directly after writing the terminal clearance sequence (`\r\033[K`) will leave an awkward extraneous blank line where the user's `^C` input residue used to be.
+**Action:** Always ensure that cancellation messages do not contain leading newlines when they are intended to overwrite `^C` residue on the same line, preserving vertical layout spacing consistency.

--- a/main.py
+++ b/main.py
@@ -3229,7 +3229,7 @@ def main() -> bool:
             sys.stderr.write("\r\033[K")
             sys.stderr.flush()
         print(
-            f"\n{Colors.WARNING}⚠️  Sync cancelled by user. Finishing current task...{Colors.ENDC}"
+            f"{Colors.WARNING}⚠️  Sync cancelled by user. Finishing current task...{Colors.ENDC}"
         )
 
         # Try to recover stats for the interrupted profile


### PR DESCRIPTION
💡 What: Removed a leading newline character (`\n`) from the "Sync cancelled by user" cancellation message printed when catching a `KeyboardInterrupt` in the main loop. 
🎯 Why: When the script intercepts `Ctrl+C`, it clears the terminal line residue (`^C`) using `\r\033[K`. Printing a message with a leading newline immediately afterward causes the cursor to jump down, leaving an awkward blank line exactly where the user's input residue used to be.
📸 Before/After: Before, cancelling the sync created an empty line above the warning message. After, the warning message neatly overwrites the `^C` residue on the same line, preserving vertical flow.
♿ Accessibility: Ensures cleaner and more predictable terminal output, benefiting users parsing output logs or using screen readers in CLI workflows.

---
*PR created automatically by Jules for task [15711386378543760132](https://jules.google.com/task/15711386378543760132) started by @abhimehro*