### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Bandit security warnings (B108, B104)

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -235,16 +235,16 @@ def test_parse_args_config_default_is_none(monkeypatch):
 
 def test_parse_args_config_long_flag(monkeypatch):
     monkeypatch.setattr(
-        sys, "argv", ["main.py", "--config", "/tmp/cfg.yaml", "--dry-run"]
+        sys, "argv", ["main.py", "--config", "cfg.yaml", "--dry-run"]
     )
     args = main.parse_args()
-    assert args.config == "/tmp/cfg.yaml"
+    assert args.config == "cfg.yaml"
 
 
 def test_parse_args_config_short_flag(monkeypatch):
-    monkeypatch.setattr(sys, "argv", ["main.py", "-c", "/tmp/cfg.yaml", "--dry-run"])
+    monkeypatch.setattr(sys, "argv", ["main.py", "-c", "cfg.yaml", "--dry-run"])
     args = main.parse_args()
-    assert args.config == "/tmp/cfg.yaml"
+    assert args.config == "cfg.yaml"
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/test_ssrf_enhanced.py
+++ b/tests/test_ssrf_enhanced.py
@@ -47,7 +47,7 @@ class TestSSRFEnhanced(unittest.TestCase):
         with patch("socket.getaddrinfo") as mock_getaddrinfo:
             # Simulate resolving to 0.0.0.0
             mock_getaddrinfo.return_value = [
-                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("0.0.0.0", 443))
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("0.0.0.0", 443))  # nosec B104
             ]
 
             url = "https://zero.example.com/config.json"


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Bandit linter identified potential security issues in tests: insecure usage of hardcoded temporary directories (B108) and potential binding to all interfaces (B104).
🎯 Impact: While these occur in test files and don't affect production security, resolving them removes noise from security scanners and ensures tests follow best practices for resource allocation and mocked data.
🔧 Fix:
- In `tests/test_config.py`, replaced the hardcoded `/tmp/cfg.yaml` path with a relative `cfg.yaml` path, which perfectly satisfies the test assertions while avoiding the B108 warning.
- In `tests/test_ssrf_enhanced.py`, added a `# nosec B104` directive to the mock DNS resolution test since `0.0.0.0` is being used safely within a mock return value to test SSRF protections.
✅ Verification: Ran `uv tool run bandit -r . -ll` to confirm that the repo no longer triggers B108 or B104 warnings, and ran `uv run pytest` to ensure all tests still pass (374/374).

---
*PR created automatically by Jules for task [16575550744821189167](https://jules.google.com/task/16575550744821189167) started by @abhimehro*