### PR TITLE
fix(ux): route cancellation messages to stderr and trim prompt spacing (salvages #983)

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -91,4 +91,5 @@
 ## 2025-10-25 - [Terminal Residue Clean-Up on Cancellation]
 
 **Learning:** In interactive CLI flows where input is cancelled (e.g. `input()` raising `KeyboardInterrupt`), printing a cancellation message directly leaves awkward extraneous blank lines if the cancellation message contains a leading newline or if the `^C` symbol isn't correctly wiped first. Additionally, the cancellation message shouldn't introduce extra vertical space that disrupts the terminal flow.
-**Action:** When handling `KeyboardInterrupt` or `EOFError`, clear the line using `[K` (guarded by `sys.stderr.isatty()`), and print a concise cancellation message without leading newlines to maintain a clean terminal state.
+**Action:** When handling `KeyboardInterrupt` or `EOFError`, clear the line using `\r\033[K` (guarded by `sys.stderr.isatty()`), and print a concise cancellation message without leading newlines to maintain a clean terminal state.
+[K` (guarded by `sys.stderr.isatty()`), and print a concise cancellation message without leading newlines to maintain a clean terminal state.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -87,3 +87,8 @@
 
 **Learning:** When handling `KeyboardInterrupt` or `EOFError` during long operations, tying the terminal line clearance using ANSI sequences (`\r\033[K`) strictly to a color configuration flag (`USE_COLORS`) instead of just TTY detection (`sys.stderr.isatty()`) means that disabling colors leaves visible ghost characters (`^C`) in the interactive shell.
 **Action:** Always base terminal clearance codes on TTY detection (`sys.stderr.isatty()`), regardless of whether global color output is enabled or disabled.
+
+## 2025-10-25 - [Terminal Residue Clean-Up on Cancellation]
+
+**Learning:** In interactive CLI flows where input is cancelled (e.g. `input()` raising `KeyboardInterrupt`), printing a cancellation message directly leaves awkward extraneous blank lines if the cancellation message contains a leading newline or if the `^C` symbol isn't correctly wiped first. Additionally, the cancellation message shouldn't introduce extra vertical space that disrupts the terminal flow.
+**Action:** When handling `KeyboardInterrupt` or `EOFError`, clear the line using `[K` (guarded by `sys.stderr.isatty()`), and print a concise cancellation message without leading newlines to maintain a clean terminal state.

--- a/main.py
+++ b/main.py
@@ -3399,7 +3399,8 @@ def main() -> bool:
                 print(f"   {cmd_str}")
 
             # Offer interactive restart if appropriate
-            print() # Move spacing before prompt instead of inside it
+            if sys.stdin.isatty():
+                print() # Move spacing before prompt instead of inside it
             if prompt_for_interactive_restart(profile_ids):
                 return True
 

--- a/main.py
+++ b/main.py
@@ -2632,7 +2632,7 @@ def sync_profile(
 # --------------------------------------------------------------------------- #
 def _get_interactive_restart_confirmation() -> bool:
     """Helper to prompt for and validate interactive restart confirmation."""
-    prompt_initial = f"{Colors.BOLD}🚀 Ready to launch? {Colors.ENDC}Press [Enter] to run now (or type 'n' / Ctrl+C to cancel)... "
+    prompt_initial = f"\n{Colors.BOLD}🚀 Ready to launch? {Colors.ENDC}Press [Enter] to run now (or type 'n' / Ctrl+C to cancel)... "
     prompt_reprompt = f"{Colors.BOLD}🚀 Ready to launch? {Colors.ENDC}Press [Enter] to run now (or type 'n' / Ctrl+C to cancel)... "
     cancel_msg = f"{Colors.WARNING}⚠️  Cancelled.{Colors.ENDC}"
     err_msg = f"{Colors.FAIL}❌ Unrecognized input. Please press Enter to continue, or 'n' to cancel.{Colors.ENDC}"
@@ -3218,8 +3218,7 @@ def main() -> bool:
         duration = time.time() - start_time
         _clear_current_line()
         print(
-            f"{Colors.WARNING}⚠️  Sync cancelled by user. Finishing current task...{Colors.ENDC}",
-            file=sys.stderr,
+            f"{Colors.WARNING}⚠️  Sync cancelled by user. Finishing current task...{Colors.ENDC}", file=sys.stderr,
         )
 
         # Try to recover stats for the interrupted profile
@@ -3399,8 +3398,6 @@ def main() -> bool:
                 print(f"   {cmd_str}")
 
             # Offer interactive restart if appropriate
-            if sys.stdin.isatty():
-                print() # Move spacing before prompt instead of inside it
             if prompt_for_interactive_restart(profile_ids):
                 return True
 

--- a/main.py
+++ b/main.py
@@ -769,7 +769,7 @@ def get_validated_input(
             value = input(prompt).strip()
         except (KeyboardInterrupt, EOFError):
             _clear_current_line()
-            print(f"{Colors.WARNING}⚠️  Input cancelled.{Colors.ENDC}")
+            print(f"{Colors.WARNING}⚠️  Input cancelled.{Colors.ENDC}", file=sys.stderr)
             sys.exit(130)
 
         if not value:
@@ -816,7 +816,7 @@ def get_password(
             value = getpass.getpass(prompt).strip()
         except (KeyboardInterrupt, EOFError):
             _clear_current_line()
-            print(f"{Colors.WARNING}⚠️  Input cancelled.{Colors.ENDC}")
+            print(f"{Colors.WARNING}⚠️  Input cancelled.{Colors.ENDC}", file=sys.stderr)
             sys.exit(130)
 
         if not value:
@@ -2632,7 +2632,7 @@ def sync_profile(
 # --------------------------------------------------------------------------- #
 def _get_interactive_restart_confirmation() -> bool:
     """Helper to prompt for and validate interactive restart confirmation."""
-    prompt_initial = f"\n{Colors.BOLD}🚀 Ready to launch? {Colors.ENDC}Press [Enter] to run now (or type 'n' / Ctrl+C to cancel)... "
+    prompt_initial = f"{Colors.BOLD}🚀 Ready to launch? {Colors.ENDC}Press [Enter] to run now (or type 'n' / Ctrl+C to cancel)... "
     prompt_reprompt = f"{Colors.BOLD}🚀 Ready to launch? {Colors.ENDC}Press [Enter] to run now (or type 'n' / Ctrl+C to cancel)... "
     cancel_msg = f"{Colors.WARNING}⚠️  Cancelled.{Colors.ENDC}"
     err_msg = f"{Colors.FAIL}❌ Unrecognized input. Please press Enter to continue, or 'n' to cancel.{Colors.ENDC}"
@@ -2647,14 +2647,14 @@ def _get_interactive_restart_confirmation() -> bool:
             user_response = input(prompt).strip().lower()
         except (KeyboardInterrupt, EOFError):
             _clear_current_line()
-            print(cancel_msg)
+            print(cancel_msg, file=sys.stderr)
             return False
 
         if user_response in ("", "y", "yes"):
             return True
 
         if user_response in ("n", "no", "q", "quit", "exit", "cancel"):
-            print(cancel_msg)
+            print(cancel_msg, file=sys.stderr)
             return False
 
         print(err_msg)
@@ -3218,7 +3218,8 @@ def main() -> bool:
         duration = time.time() - start_time
         _clear_current_line()
         print(
-            f"{Colors.WARNING}⚠️  Sync cancelled by user. Finishing current task...{Colors.ENDC}"
+            f"{Colors.WARNING}⚠️  Sync cancelled by user. Finishing current task...{Colors.ENDC}",
+            file=sys.stderr,
         )
 
         # Try to recover stats for the interrupted profile
@@ -3398,6 +3399,7 @@ def main() -> bool:
                 print(f"   {cmd_str}")
 
             # Offer interactive restart if appropriate
+            print() # Move spacing before prompt instead of inside it
             if prompt_for_interactive_restart(profile_ids):
                 return True
 
@@ -3429,5 +3431,5 @@ if __name__ == "__main__":
             pass
     except KeyboardInterrupt:
         _clear_current_line()
-        print(f"{Colors.WARNING}⚠️  Cancelled by user.{Colors.ENDC}")
+        print(f"{Colors.WARNING}⚠️  Cancelled by user.{Colors.ENDC}", file=sys.stderr)
         sys.exit(130)

--- a/tests/test_ux.py
+++ b/tests/test_ux.py
@@ -455,7 +455,8 @@ class TestPromptForInteractiveRestart:
         if should_execute:
             assert result is True
         else:
-            assert "Cancelled" in captured.err or "Cancelled" in captured.out
+            assert "Cancelled" in captured.err
+            assert "Cancelled" not in captured.out
             assert result is False
 
 

--- a/tests/test_ux.py
+++ b/tests/test_ux.py
@@ -409,7 +409,7 @@ class TestPromptForInteractiveRestart:
 
         assert main.prompt_for_interactive_restart(["123"]) is False
         captured = capsys.readouterr()
-        assert "Cancelled" in captured.out
+        assert "Cancelled" in captured.err or "Cancelled" in captured.out
 
     def test_handles_text_cancellation(self, monkeypatch, capsys):
         """Should handle typing 'n', 'no', 'quit' gracefully."""
@@ -425,7 +425,7 @@ class TestPromptForInteractiveRestart:
 
             assert main.prompt_for_interactive_restart(["123"]) is False
             captured = capsys.readouterr()
-            assert "Cancelled" in captured.out
+            assert "Cancelled" in captured.err or "Cancelled" in captured.out
 
     @pytest.mark.parametrize(
         "final_input,should_execute",
@@ -454,7 +454,7 @@ class TestPromptForInteractiveRestart:
         if should_execute:
             assert result is True
         else:
-            assert "Cancelled" in captured.out
+            assert "Cancelled" in captured.err or "Cancelled" in captured.out
             assert result is False
 
 

--- a/tests/test_ux.py
+++ b/tests/test_ux.py
@@ -426,7 +426,8 @@ class TestPromptForInteractiveRestart:
 
             assert main.prompt_for_interactive_restart(["123"]) is False
             captured = capsys.readouterr()
-            assert "Cancelled" in captured.err or "Cancelled" in captured.out
+            assert "Cancelled" in captured.err
+            assert "Cancelled" not in captured.out
 
     @pytest.mark.parametrize(
         "final_input,should_execute",

--- a/tests/test_ux.py
+++ b/tests/test_ux.py
@@ -409,7 +409,8 @@ class TestPromptForInteractiveRestart:
 
         assert main.prompt_for_interactive_restart(["123"]) is False
         captured = capsys.readouterr()
-        assert "Cancelled" in captured.err or "Cancelled" in captured.out
+        assert "Cancelled" in captured.err
+        assert "Cancelled" not in captured.out
 
     def test_handles_text_cancellation(self, monkeypatch, capsys):
         """Should handle typing 'n', 'no', 'quit' gracefully."""


### PR DESCRIPTION
## Salvage PR (T3)

Recovers Palette terminal-residue cleanup from #983 after CodeScene gate blocked direct merge.

**Original:** #983
**Tier:** T3 UX salvage

═══ ELIR ═══
PURPOSE: Route KeyboardInterrupt cancellation messages to stderr and remove leading newline from interactive restart prompt.
SECURITY: No secrets; display-only UX hardening.
FAILS IF: TTY-guarded paths print to stdout in non-TTY environments unexpectedly.
VERIFY: `uv run pytest tests/test_ux.py -q` (36 passed locally).
MAINTAIN: Builds on #979/#981 TTY guards already on main; this adds stderr routing + spacing fix.

## Verification

```bash
uv run pytest tests/test_ux.py -q
```