### PR TITLE
🎨 Palette: Fix leading newline in interactive prompt

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -93,3 +93,8 @@
 **Learning:** In interactive CLI flows where input is cancelled (e.g. `input()` raising `KeyboardInterrupt`), printing a cancellation message directly leaves awkward extraneous blank lines if the cancellation message contains a leading newline or if the `^C` symbol isn't correctly wiped first. Additionally, the cancellation message shouldn't introduce extra vertical space that disrupts the terminal flow.
 **Action:** When handling `KeyboardInterrupt` or `EOFError`, clear the line using `\r\033[K` (guarded by `sys.stderr.isatty()`), and print a concise cancellation message without leading newlines to maintain a clean terminal state.
 [K` (guarded by `sys.stderr.isatty()`), and print a concise cancellation message without leading newlines to maintain a clean terminal state.
+
+## 2026-07-05 - [Terminal Residue Clean-Up on Cancellation]
+
+**Learning:** In interactive CLI flows where input is cancelled (e.g. `input()` raising `KeyboardInterrupt`), printing a cancellation message directly leaves awkward extraneous blank lines if the prompt string contains a leading newline, which breaks terminal clearing logic (`\r\033[K`) by displacing the cursor.
+**Action:** When printing vertical spacing before interactive prompts, print it structurally using an explicit `print()` rather than embedding a leading newline (`\n`) directly in the prompt string.

--- a/main.py
+++ b/main.py
@@ -2632,11 +2632,12 @@ def sync_profile(
 # --------------------------------------------------------------------------- #
 def _get_interactive_restart_confirmation() -> bool:
     """Helper to prompt for and validate interactive restart confirmation."""
-    prompt_initial = f"\n{Colors.BOLD}🚀 Ready to launch? {Colors.ENDC}Press [Enter] to run now (or type 'n' / Ctrl+C to cancel)... "
+    prompt_initial = f"{Colors.BOLD}🚀 Ready to launch? {Colors.ENDC}Press [Enter] to run now (or type 'n' / Ctrl+C to cancel)... "
     prompt_reprompt = f"{Colors.BOLD}🚀 Ready to launch? {Colors.ENDC}Press [Enter] to run now (or type 'n' / Ctrl+C to cancel)... "
     cancel_msg = f"{Colors.WARNING}⚠️  Cancelled.{Colors.ENDC}"
     err_msg = f"{Colors.FAIL}❌ Unrecognized input. Please press Enter to continue, or 'n' to cancel.{Colors.ENDC}"
 
+    print()  # Add vertical space structurally to avoid terminal clearing issues on KeyboardInterrupt
     prompt = prompt_initial
 
     while True:

--- a/pr_body.json
+++ b/pr_body.json
@@ -1,6 +1,6 @@
 {
-  "title": "🎨 Palette: Fix terminal residue cleanup for NO_COLOR environments",
-  "head": "jules-12988657735329617174-c85629af",
-  "base": "main",
-  "body": "💡 What: Detached the terminal line clearance logic (`\\r\\033[K`) from the `USE_COLORS` configuration flag, relying strictly on `sys.stderr.isatty()` instead. Refactored the inline clearance logic scattered across exception handlers to use the single `_clear_current_line()` helper function.\n\n🎯 Why: When global color output is disabled (e.g., via `NO_COLOR=1`), hitting `Ctrl+C` during an interactive session leaves ugly `^C` ghost characters on the terminal line. The terminal clearance sequence works independently of color configurations and should be executed whenever running in an interactive TTY.\n\n📸 Before/After: Visual ghost characters (`^C`) no longer linger on the screen when canceling prompts in uncolored mode.\n\n♿ Accessibility: Improves the clarity and cleanliness of the CLI fallback mode."
+  "title": "🎨 Palette: Fix leading newline in interactive prompt",
+  "body": "💡 What: Extracted the leading newline `\\n` from `prompt_initial` into a standalone `print()` call within `_get_interactive_restart_confirmation` in `main.py`.\n\n🎯 Why: Embedding a leading newline in `input()` prompt strings confuses the terminal's cursor positioning. When a user cancelled the prompt (e.g., via `KeyboardInterrupt` / Ctrl+C), the terminal clearing logic (`\\r\\033[K`) would fail to clear the `^C` residue and instead displace the cursor, leaving awkward extraneous blank lines. Structurally printing the vertical space before invoking the prompt keeps the terminal state clean.\n\n📸 Before/After: Visual changes affect CLI output formatting on interrupt.\n\n♿ Accessibility: Improves the resilience of the terminal UI to interrupts, ensuring a clean and consistent empty state when actions are cancelled.",
+  "head": "jules-ux-prompt-fix",
+  "base": "main"
 }


### PR DESCRIPTION
💡 What: Extracted the leading newline `\n` from `prompt_initial` into a standalone `print()` call within `_get_interactive_restart_confirmation` in `main.py`.

🎯 Why: Embedding a leading newline in `input()` prompt strings confuses the terminal's cursor positioning. When a user cancelled the prompt (e.g., via `KeyboardInterrupt` / Ctrl+C), the terminal clearing logic (`\r\033[K`) would fail to clear the `^C` residue and instead displace the cursor, leaving awkward extraneous blank lines. Structurally printing the vertical space before invoking the prompt keeps the terminal state clean.

📸 Before/After: Visual changes affect CLI output formatting on interrupt.

♿ Accessibility: Improves the resilience of the terminal UI to interrupts, ensuring a clean and consistent empty state when actions are cancelled.

---
*PR created automatically by Jules for task [11474065873394514816](https://jules.google.com/task/11474065873394514816) started by @abhimehro*