### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix TOCTOU vulnerability in cache.py

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -35,3 +35,8 @@
 **Vulnerability:** The bandit tool flagged `random.choice(success_msgs)` as low severity since it uses standard pseudo-random generators instead of cryptographic ones.
 **Learning:** Using `random` instead of `secrets` triggers security linting errors (B311) even in non-cryptographic contexts. Standardizing on `secrets` across the codebase ensures we satisfy security tools and never accidentally use an insecure PRNG in a sensitive context.
 **Prevention:** Always use the `secrets` module instead of `random` when performing randomized selections or number generation.
+
+## 2026-07-05 - TOCTOU Vulnerability in Cache Directory Creation
+**Vulnerability:** The cache directory was created using `mkdir()` without specifying the mode, and then `chmod(0o700)` was applied afterward. This creates a Time-Of-Check to Time-Of-Use (TOCTOU) race condition where the directory exists with default (potentially broader) permissions for a brief window before being secured.
+**Learning:** Securing file system objects requires applying the restrictive permissions at the exact moment of creation, not as a subsequent operation.
+**Prevention:** Always pass the required restrictive mode (e.g., `mode=0o700`) directly to the creation function like `mkdir()` or `open()` to ensure atomic application of security boundaries.

--- a/cache.py
+++ b/cache.py
@@ -204,7 +204,7 @@ def save_disk_cache() -> None:
     """
     try:
         cache_dir = get_cache_dir()
-        cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
 
         # Set directory permissions to user-only (rwx------).
         if platform.system() != "Windows":


### PR DESCRIPTION
This pull request addresses a Time-Of-Check to Time-Of-Use (TOCTOU) vulnerability in the creation of the persistent blocklist cache directory.

Previously, the directory was created using `cache_dir.mkdir()` with default permissions and subsequently locked down using `chmod(0o700)`. This left a brief window during which the directory could be accessed by other local users with default permissions before the security boundary was enforced.

This change passes the restrictive permissions directly to the creation function (`cache_dir.mkdir(mode=0o700, ...)`), ensuring the directory is created atomically with secure permissions. This prevents the TOCTOU race condition entirely.

The `sentinel.md` journal has been updated with these learnings to prevent future regressions.

---
*PR created automatically by Jules for task [12034574338180574352](https://jules.google.com/task/12034574338180574352) started by @abhimehro*