### PR TITLE
🎨 Palette: Fix terminal residue for prompts with leading newlines

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -98,3 +98,8 @@
 
 **Learning:** In interactive CLI flows where input is cancelled (e.g. `input()` raising `KeyboardInterrupt`), printing a cancellation message directly leaves awkward extraneous blank lines if the prompt string contains a leading newline, which breaks terminal clearing logic (`\r\033[K`) by displacing the cursor.
 **Action:** When printing vertical spacing before interactive prompts, print it structurally using an explicit `print()` rather than embedding a leading newline (`\n`) directly in the prompt string.
+
+## YYYY-MM-DD - [Structural Prompt Spacing in Generic Inputs]
+
+**Learning:** When using generic wrappers like `get_validated_input()` or `get_password()`, adding a leading newline to the prompt string causes terminal clearing logic (`\r\033[K`) on `KeyboardInterrupt` to break, leaving awkward extraneous blank lines.
+**Action:** In generic input wrappers, if a prompt starts with a newline, strip it from the prompt string and print a blank line structurally (using an explicit `print()`) before executing the input loop to maintain a clean terminal state.

--- a/main.py
+++ b/main.py
@@ -759,6 +759,10 @@ def get_validated_input(
     error_msg: str,
 ) -> str:
     """Prompts for input until the validator returns True."""
+    if prompt.startswith("\n"):
+        print()
+        prompt = prompt[1:]
+
     if not _ANSI_ESCAPE_PATTERN.sub("", prompt).endswith(" "):
         prompt += " "
 
@@ -807,6 +811,10 @@ def get_password(
     out by including the literal substring "(typing will be hidden)" in
     the prompt they pass.
     """
+    if prompt.startswith("\n"):
+        print()
+        prompt = prompt[1:]
+
     prompt = _format_password_prompt(prompt)
 
     while True:

--- a/pr_body.json
+++ b/pr_body.json
@@ -1,3 +1,6 @@
 {
-  "body": "💡 What: Replaced `len(r[\"profile\"])` with `_display_len(r[\"profile\"])` when calculating `max_profile_len` in `print_summary_table` within `main.py`.\n\n🎯 Why: If a profile name contains emojis or full-width characters, `len()` calculates the raw character count, which causes the column width to be misaligned because terminal emulators render emojis across two columns. `_display_len` accurately counts these characters as 2 visual columns.\n\n📸 Before/After: Visual changes affect CLI table output formatting.\n\n♿ Accessibility: N/A"
+  "title": "🎨 Palette: Fix terminal residue for prompts with leading newlines",
+  "body": "💡 What\nStrips leading newlines from prompt strings in generic input wrappers (`get_validated_input` and `get_password`) and prints them structurally before the input loop.\n\n🎯 Why\nFixes terminal residue (extra blank lines) left behind upon cancellation (`KeyboardInterrupt`) because leading newlines inside prompt strings displace the cursor during terminal clearing (`\\r\\033[K`).\n\n📸 Before/After\nN/A (Terminal CLI fix).\n\n♿ Accessibility\nPrevents terminal output clutter, keeping the CLI flow clean and predictable for all users.",
+  "head": "jules-12638074770790121843-b0f7a550",
+  "base": "main"
 }


### PR DESCRIPTION
💡 What
Strips leading newlines from prompt strings in generic input wrappers (`get_validated_input` and `get_password`) and prints them structurally before the input loop.

🎯 Why
Fixes terminal residue (extra blank lines) left behind upon cancellation (`KeyboardInterrupt`) because leading newlines inside prompt strings displace the cursor during terminal clearing (`\r\033[K`).

📸 Before/After
N/A (Terminal CLI fix).

♿ Accessibility
Prevents terminal output clutter, keeping the CLI flow clean and predictable for all users.

---
*PR created automatically by Jules for task [12638074770790121843](https://jules.google.com/task/12638074770790121843) started by @abhimehro*