### PR TITLE
🎨 Palette: Fix leading newlines in prompts with ANSI codes

### DIFF
--- a/main.py
+++ b/main.py
@@ -759,9 +759,10 @@ def get_validated_input(
     error_msg: str,
 ) -> str:
     """Prompts for input until the validator returns True."""
-    while prompt.startswith("\n"):
+    while _ANSI_ESCAPE_PATTERN.sub("", prompt).startswith("\n"):
         print()
-        prompt = prompt[1:]
+        first_newline_idx = prompt.find("\n")
+        prompt = prompt[:first_newline_idx] + prompt[first_newline_idx + 1:]
 
     if not _ANSI_ESCAPE_PATTERN.sub("", prompt).endswith(" "):
         prompt += " "
@@ -790,9 +791,10 @@ def get_validated_input(
 
 def _format_password_prompt(prompt: str) -> str:
     """Formats the password prompt to ensure it contains standard hints and spaces."""
-    while prompt.startswith("\n"):
+    while _ANSI_ESCAPE_PATTERN.sub("", prompt).startswith("\n"):
         print()
-        prompt = prompt[1:]
+        first_newline_idx = prompt.find("\n")
+        prompt = prompt[:first_newline_idx] + prompt[first_newline_idx + 1:]
 
     if "(typing will be hidden)" not in prompt:
         prompt = f"{prompt.rstrip()} (typing will be hidden) "


### PR DESCRIPTION
💡 What: Ensure leading newlines are extracted as structural space even when prompts begin with ANSI escape codes.
🎯 Why: Without this, newlines embedded after color sequences break terminal cursor tracking and leave ghost characters when an input is cancelled via KeyboardInterrupt.
📸 Before/After: Visual fix for Terminal Residue.
♿ Accessibility: Clean terminal state.

---
*PR created automatically by Jules for task [15269492931416848806](https://jules.google.com/task/15269492931416848806) started by @abhimehro*