### PR TITLE
🎨 Palette: Fix ANSI color code interference with interactive prompt formatting

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -98,3 +98,7 @@
 
 **Learning:** In interactive CLI flows where input is cancelled (e.g. `input()` raising `KeyboardInterrupt`), printing a cancellation message directly leaves awkward extraneous blank lines if the prompt string contains a leading newline, which breaks terminal clearing logic (`\r\033[K`) by displacing the cursor.
 **Action:** When printing vertical spacing before interactive prompts, print it structurally using an explicit `print()` rather than embedding a leading newline (`\n`) directly in the prompt string.
+
+## 2024-07-14 - ANSI escape codes in interactive prompts
+**Learning:** Checking for structural newlines at the beginning of an input prompt using `.startswith("\n")` fails if the prompt is styled with ANSI escape codes (e.g., `Colors.BOLD`). This leaves the newlines inside the `input()` call, which breaks terminal cursor clearing logic upon `KeyboardInterrupt`.
+**Action:** Always strip ANSI escape codes before programmatically checking or manipulating prompt string boundaries, and use `.replace()` rather than slicing `[1:]` to remove the newline.

--- a/main.py
+++ b/main.py
@@ -759,9 +759,9 @@ def get_validated_input(
     error_msg: str,
 ) -> str:
     """Prompts for input until the validator returns True."""
-    while prompt.startswith("\n"):
+    while _ANSI_ESCAPE_PATTERN.sub("", prompt).startswith("\n"):
         print()
-        prompt = prompt[1:]
+        prompt = prompt.replace("\n", "", 1)
 
     if not _ANSI_ESCAPE_PATTERN.sub("", prompt).endswith(" "):
         prompt += " "
@@ -790,9 +790,9 @@ def get_validated_input(
 
 def _format_password_prompt(prompt: str) -> str:
     """Formats the password prompt to ensure it contains standard hints and spaces."""
-    while prompt.startswith("\n"):
+    while _ANSI_ESCAPE_PATTERN.sub("", prompt).startswith("\n"):
         print()
-        prompt = prompt[1:]
+        prompt = prompt.replace("\n", "", 1)
 
     if "(typing will be hidden)" not in prompt:
         prompt = f"{prompt.rstrip()} (typing will be hidden) "


### PR DESCRIPTION
💡 What: Fixed leading newline extraction in interactive prompts to properly account for ANSI color codes.
🎯 Why: If a prompt started with a color code (e.g. `Colors.BOLD`), the newline was not extracted correctly, leaving it in the `input()` call and breaking terminal cursor clearing logic on `KeyboardInterrupt`.
📸 Before/After: Visual structural spacing on cancellation is now consistent.
♿ Accessibility: N/A

---
*PR created automatically by Jules for task [15226821770883278856](https://jules.google.com/task/15226821770883278856) started by @abhimehro*