### PR TITLE
🎨 Palette: Add countdown timer for folder polling

### DIFF
--- a/api_client.py
+++ b/api_client.py
@@ -274,6 +274,7 @@ def _log_debug_response_content(e: Exception) -> None:
     if response is not None:
         log.debug(f"Response content: {_sanitize_fn(response.text)}")
 
+
 def _handle_rate_limit(
     e: httpx.HTTPStatusError, attempt: int, max_retries: int
 ) -> bool:

--- a/main.py
+++ b/main.py
@@ -2153,10 +2153,9 @@ def _poll_for_folder_id(ctx: SyncContext, name: str) -> str | None:
 
         if attempt < MAX_RETRIES:
             wait_time = FOLDER_CREATION_DELAY * (attempt + 1)
-            log.info(
-                f"Folder '{sanitize_for_log(name)}' not found yet. Retrying in {wait_time}s..."
+            countdown_timer(
+                wait_time, f"Waiting for folder '{sanitize_for_log(name)}' to appear"
             )
-            time.sleep(wait_time)
 
     log.error(
         f"Folder {sanitize_for_log(name)} was not found after creation and retries."

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,6 +1,6 @@
 # ABHI-1481: SSRF domain allowlisting
 
-**Route:** T1+S+H  
+**Route:** T1+S+H
 **Threat model:** User-controlled blocklist URLs (config/CLI) drive outbound HTTPS fetches. Existing IP/hostname checks reduce risk; deny-by-default domain allowlisting shrinks the residual attack surface. Control D API base is hardcoded but should be host-pinned for defense in depth.
 
 **Trust boundaries:**

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -318,6 +318,7 @@ class TestApiHostPinning:
             api_client._assert_api_url(
                 "https://api.controld.com.evil.com/profiles/abc/groups"
             )
+
     @pytest.mark.parametrize(
         "url",
         [

--- a/tests/test_api_tracking.py
+++ b/tests/test_api_tracking.py
@@ -71,7 +71,9 @@ class TestAPITracking(unittest.TestCase):
 
         # Call _api_post
         main._api_post(
-            mock_client, "https://api.controld.com/profiles/test/groups", {"key": "value"}
+            mock_client,
+            "https://api.controld.com/profiles/test/groups",
+            {"key": "value"},
         )
 
         # Verify counter was incremented by 1
@@ -113,7 +115,9 @@ class TestAPITracking(unittest.TestCase):
 
         # Call _api_post_form
         main._api_post_form(
-            mock_client, "https://api.controld.com/profiles/test/rules", {"key": "value"}
+            mock_client,
+            "https://api.controld.com/profiles/test/rules",
+            {"key": "value"},
         )
 
         # Verify counter was incremented by 1
@@ -133,7 +137,9 @@ class TestAPITracking(unittest.TestCase):
         mock_client.post.return_value = mock_response
 
         main._api_post_form(
-            mock_client, "https://api.controld.com/profiles/test/rules", {"key": "value"}
+            mock_client,
+            "https://api.controld.com/profiles/test/rules",
+            {"key": "value"},
         )
 
         # Verify the post was made with the correct Content-Type header

--- a/tests/test_ssrf_protection.py
+++ b/tests/test_ssrf_protection.py
@@ -45,7 +45,9 @@ def test_controld_domains_rejected_for_blocklist_fetches():
     main.set_allowed_blocklist_domains(None)
     assert main.validate_folder_url("https://controld.com/blocklist.json") is False
     assert main.validate_folder_url("https://api.controld.com/blocklist.json") is False
-    assert main.validate_folder_url("https://status.controld.com/blocklist.json") is False
+    assert (
+        main.validate_folder_url("https://status.controld.com/blocklist.json") is False
+    )
 
 
 def test_default_allowlist_contains_recommended_hosts():


### PR DESCRIPTION
💡 What: Added countdown_timer in place of time.sleep during _poll_for_folder_id.
🎯 Why: Provides an immediate, visual progress bar to avoid anxiety from a frozen terminal.
📸 Before/After: Replaced static log statement with a dynamic progress bar.
♿ Accessibility: N/A

---
*PR created automatically by Jules for task [2689534036727810940](https://jules.google.com/task/2689534036727810940) started by @abhimehro*