### PR TITLE
🎨 Palette: Fix hardcoded ANSI color in rate limit status

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -107,3 +107,8 @@
 
 **Learning:** When displaying multiple blocks of statistical data in the terminal (like API calls, cache hits, rate limits), using bold text alone for section headers isn't enough to make the data quickly scannable, especially when the surrounding text is dense.
 **Action:** Always add semantic emojis (like 📊, ⚡, 🚦) to the start of statistical or categorical section headers. Emojis act as strong visual anchors, allowing users to instantly locate the information they need in a dense CLI output.
+
+## YYYY-MM-DD - [Terminal Color Hardcoding]
+
+**Learning:** When displaying data tables or CLI interfaces, hardcoding ANSI escape codes (e.g. `Colors.BOLD`) without checking if `USE_COLORS` is active creates an unpolished and confusing UX in environments where colors are disabled or unsupported (like CI pipelines or when NO_COLOR is set).
+**Action:** Always check `USE_COLORS` before embedding ANSI escape codes in CLI output, and provide a clean fallback string (e.g., maintaining semantic emojis but dropping the `Colors` attributes) to ensure graceful degradation.

--- a/main.py
+++ b/main.py
@@ -3102,7 +3102,10 @@ def display_rate_limit_status() -> None:
         if not any(v is not None for v in _rate_limit_info.values()):
             return
 
-        print(f"{Colors.BOLD}🚦 API Rate Limit Status:{Colors.ENDC}")
+        if USE_COLORS:
+            print(f"{Colors.BOLD}🚦 API Rate Limit Status:{Colors.ENDC}")
+        else:
+            print("🚦 API Rate Limit Status:")
 
         if _rate_limit_info["limit"] is not None:
             print(f"  • Requests limit:       {_rate_limit_info['limit']:>6,}")


### PR DESCRIPTION
### 💡 What:
Added a `USE_COLORS` check to the `display_rate_limit_status()` method.

### 🎯 Why:
The `display_rate_limit_status` output was unconditionally rendering `Colors.BOLD`, causing visible `\033[1m` characters in terminals where `USE_COLORS` is disabled (e.g., `NO_COLOR=1` or non-interactive environments). This ensures graceful degradation while keeping the semantic emoji intact.

### ♿ Accessibility:
Improves readability in non-TTY environments.

---
*PR created automatically by Jules for task [18258714422559252421](https://jules.google.com/task/18258714422559252421) started by @abhimehro*