### PR TITLE
fix(cli): USE_COLORS for rate-limit header (salvages #1030)

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -107,3 +107,8 @@
 
 **Learning:** When displaying multiple blocks of statistical data in the terminal (like API calls, cache hits, rate limits), using bold text alone for section headers isn't enough to make the data quickly scannable, especially when the surrounding text is dense.
 **Action:** Always add semantic emojis (like 📊, ⚡, 🚦) to the start of statistical or categorical section headers. Emojis act as strong visual anchors, allowing users to instantly locate the information they need in a dense CLI output.
+
+## 2026-07-19 - [Terminal Color Hardcoding]
+
+**Learning:** When displaying data tables or CLI interfaces, hardcoding ANSI escape codes (e.g. `Colors.BOLD`) without checking if `USE_COLORS` is active creates an unpolished and confusing UX in environments where colors are disabled or unsupported (like CI pipelines or when NO_COLOR is set).
+**Action:** Always check `USE_COLORS` before embedding ANSI escape codes in CLI output, and provide a clean fallback string (e.g., maintaining semantic emojis but dropping the `Colors` attributes) to ensure graceful degradation. Prefer a small helper (e.g. `_print_bold_header`) so the call site does not gain cyclomatic complexity.

--- a/main.py
+++ b/main.py
@@ -768,6 +768,18 @@ def _print_hint(hint: str) -> None:
         print(hint)
 
 
+def _print_bold_header(text: str) -> None:
+    """Print a bold section header when colors are enabled; plain text otherwise.
+
+    Isolates the USE_COLORS branch so callers (e.g. display_rate_limit_status)
+    do not gain cyclomatic complexity from the NO_COLOR / non-TTY fallback.
+    """
+    if USE_COLORS:
+        print(f"{Colors.BOLD}{text}{Colors.ENDC}")
+    else:
+        print(text)
+
+
 def get_validated_input(
     prompt: str,
     validator: Callable[[str], bool],
@@ -3102,7 +3114,7 @@ def display_rate_limit_status() -> None:
         if not any(v is not None for v in _rate_limit_info.values()):
             return
 
-        print(f"{Colors.BOLD}🚦 API Rate Limit Status:{Colors.ENDC}")
+        _print_bold_header("🚦 API Rate Limit Status:")
 
         if _rate_limit_info["limit"] is not None:
             print(f"  • Requests limit:       {_rate_limit_info['limit']:>6,}")


### PR DESCRIPTION
## Summary

Salvages [#1030](https://github.com/abhimehro/ctrld-sync/pull/1030) (Jules Palette: hardcoded ANSI in `display_rate_limit_status`).

Jules' if/else raised CodeScene **Complex Method** (9→11). This salvage keeps the `USE_COLORS` / `NO_COLOR` fix but isolates the branch in `_print_bold_header` (same pattern as `_print_hint`), so call-site complexity is unchanged.

## Changes

- `main.py`: add `_print_bold_header`; use it in `display_rate_limit_status`
- `.jules/palette.md`: append 2026-07-19 learning (append-only)

## Verification

- `uv run python -m py_compile main.py`
- `uv run ruff check main.py` — All checks passed
- `uv run pytest tests/ -q` — 364 passed

## ELIR

- **PURPOSE:** Graceful rate-limit header when colors are disabled, without CodeScene complexity regression.
- **SECURITY:** Display-only; no auth/secrets/API changes. Trust boundary unchanged.
- **FAILS IF:** `USE_COLORS` / `Colors` globals diverge from other CLI printers.
- **VERIFY:** `NO_COLOR=1 uv run python -c 'from main import display_rate_limit_status, _rate_limit_info; _rate_limit_info.update({\"limit\":100,\"remaining\":50,\"reset\":None}); display_rate_limit_status()'` (or run suite above).
- **MAINTAIN:** Prefer shared header helpers over inline `if USE_COLORS` inside already-complex display functions.

**Phase 2 salvage — do not auto-merge (S1).** Human review required.

Refs: #1030