### PR TITLE
fix(deps): sync requirements floors with pyproject (dotenv/pytest/ruff)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 # Dev dependencies - manually synchronized with pyproject.toml
 # This file is maintained for CI caching purposes only
 # Source of truth: pyproject.toml [project.optional-dependencies.dev]
-pytest>=7.0.0
+pytest>=9.0.3
 pytest-mock>=3.10.0
 pytest-xdist>=3.0.0
 pytest-benchmark>=4.0.0
@@ -10,3 +10,4 @@ pytest-cov>=4.0.0
 pre-commit>=3.0.0
 mypy>=1.9
 types-PyYAML>=6.0
+ruff>=0.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@
 # This file is maintained for CI caching purposes only
 # Source of truth: pyproject.toml [project.dependencies]
 httpx>=0.28.1
-python-dotenv>=1.1.1
+python-dotenv>=1.2.2
 pyyaml>=6.0


### PR DESCRIPTION
## Summary

Closes #1033 (Daily QA finding — CI cache manifest drift)

## Branch Naming

- [x] `fix/<short-description>` for bug fixes (cloud agent branch used for Daily QA automation)

## Before Opening a PR

1. Full test suite: `uv run pytest tests/ -q` — **364 passed**
2. Linter: `ruff check .` — **clean**
3. Pre-commit: not re-run full suite; secret-scan hooks refreshed via `make cursor-cloud-hooks`

## What Changed and Why

- [x] Sync `requirements.txt` / `requirements-dev.txt` floors with `pyproject.toml` (source of truth)
  - `python-dotenv>=1.1.1` → `>=1.2.2` (GHSA-mf9w-mj56-hr94)
  - `pytest>=7.0.0` → `>=9.0.3` (GHSA-6w46-j5rx-g56g)
  - Add `ruff>=0.9.0` to match optional-dev deps
- [x] How to verify: `uv sync --all-extras && uv run pytest tests/ -q && ruff check .`
- [x] Related: Daily QA #1033

`uv.lock` already resolved dotenv 1.2.2 and pytest 9.0.3; this only aligns CI cache floors.

## Security Implications

- [x] No secrets or credentials are introduced or exposed by this change
- Floor bumps close documented OSV findings for older dotenv/pytest lower bounds

## Checklist

- [x] Commit messages are clear and descriptive
- [x] No secrets, credentials, tokens, profiles, or `.env` files are included in this PR
- [ ] Branch follows naming convention (`fix/...`) — cloud agent branch retained for automation traceability
- [x] Documentation N/A (manifest sync only)