### PR TITLE
🎨 Palette: Add structural newlines and stderr streaming for interactive prompts

### DIFF
--- a/main.py
+++ b/main.py
@@ -760,12 +760,13 @@ def _clear_current_line() -> None:
         sys.stderr.flush()
 
 
-def _print_hint(hint: str) -> None:
+def _print_hint(hint: str, file=None) -> None:
     """Helper to cleanly print input hints while respecting USE_COLORS to reduce cyclomatic complexity."""
+    file = file or sys.stdout
     if USE_COLORS:
-        print(f"{Colors.DIM}{hint}{Colors.ENDC}")
+        print(f"{Colors.DIM}{hint}{Colors.ENDC}", file=file)
     else:
-        print(hint)
+        print(hint, file=file)
 
 
 def _print_bold_header(text: str) -> None:
@@ -804,15 +805,19 @@ def get_validated_input(
             sys.exit(130)
 
         if not value:
-            print(f"{Colors.FAIL}❌ Value cannot be empty{Colors.ENDC}")
-            _print_hint(EMPTY_INPUT_HINT)
+            print(
+                f"{Colors.FAIL}❌ Value cannot be empty{Colors.ENDC}", file=sys.stderr
+            )
+            _print_hint(EMPTY_INPUT_HINT, file=sys.stderr)
+            print(file=sys.stderr)
             continue
 
         if validator(value):
             return value
 
-        print(f"{Colors.FAIL}❌ {error_msg}{Colors.ENDC}")
-        _print_hint(INVALID_INPUT_HINT)
+        print(f"{Colors.FAIL}❌ {error_msg}{Colors.ENDC}", file=sys.stderr)
+        _print_hint(INVALID_INPUT_HINT, file=sys.stderr)
+        print(file=sys.stderr)
 
 
 def _format_password_prompt(prompt: str) -> str:
@@ -855,15 +860,19 @@ def get_password(
             sys.exit(130)
 
         if not value:
-            print(f"{Colors.FAIL}❌ Value cannot be empty{Colors.ENDC}")
-            _print_hint(EMPTY_INPUT_HINT)
+            print(
+                f"{Colors.FAIL}❌ Value cannot be empty{Colors.ENDC}", file=sys.stderr
+            )
+            _print_hint(EMPTY_INPUT_HINT, file=sys.stderr)
+            print(file=sys.stderr)
             continue
 
         if validator(value):
             return value
 
-        print(f"{Colors.FAIL}❌ {error_msg}{Colors.ENDC}")
-        _print_hint(INVALID_INPUT_HINT)
+        print(f"{Colors.FAIL}❌ {error_msg}{Colors.ENDC}", file=sys.stderr)
+        _print_hint(INVALID_INPUT_HINT, file=sys.stderr)
+        print(file=sys.stderr)
 
 
 TOKEN = _clean_env_kv(os.getenv("TOKEN"), "TOKEN")
@@ -2802,7 +2811,8 @@ def _get_interactive_restart_confirmation() -> bool:
             print(cancel_msg, file=sys.stderr)
             return False
 
-        print(err_msg)
+        print(err_msg, file=sys.stderr)
+        print(file=sys.stderr)
         prompt = prompt_reprompt
 
 

--- a/tests/test_ux.py
+++ b/tests/test_ux.py
@@ -464,7 +464,7 @@ class TestPromptForInteractiveRestart:
         result = main.prompt_for_interactive_restart(["123"])
 
         captured = capsys.readouterr()
-        assert "Unrecognized input" in captured.out
+        assert "Unrecognized input" in captured.err
         if should_execute:
             assert result is True
         else:
@@ -496,9 +496,9 @@ class TestGetValidatedInput:
         captured = capsys.readouterr()
 
         # Check that we emitted the uncolored strings for hints
-        assert main.EMPTY_INPUT_HINT in captured.out
-        assert main.INVALID_INPUT_HINT in captured.out
-        assert "\033[2m" not in captured.out  # Colors.DIM should not be there
+        assert main.EMPTY_INPUT_HINT in captured.err
+        assert main.INVALID_INPUT_HINT in captured.err
+        assert "\033[2m" not in captured.err  # Colors.DIM should not be there
 
     def test_get_validated_input_colors(self, monkeypatch, capsys):
         """Verify colored hints are printed if colors are enabled."""
@@ -527,8 +527,8 @@ class TestGetValidatedInput:
         captured = capsys.readouterr()
 
         # Check that we emitted the colored strings for hints
-        assert f"\033[2m{main.EMPTY_INPUT_HINT}\033[0m" in captured.out
-        assert f"\033[2m{main.INVALID_INPUT_HINT}\033[0m" in captured.out
+        assert f"\033[2m{main.EMPTY_INPUT_HINT}\033[0m" in captured.err
+        assert f"\033[2m{main.INVALID_INPUT_HINT}\033[0m" in captured.err
 
 
 def test_print_hint_helper_usage(monkeypatch, capsys):


### PR DESCRIPTION
💡 What: Added structural newlines before interactive input reprompts and properly streamed error messages to stderr.
🎯 Why: Prevents the terminal from feeling cramped when inputs fail, separates previous dense output blocks, and ensures that interactive error messages do not corrupt standard output when the tool is piped.
♿ Accessibility: Enhances readability and terminal screen reader parsing.

---
*PR created automatically by Jules for task [7837134500624831838](https://jules.google.com/task/7837134500624831838) started by @abhimehro*