### PR TITLE
🎨 Palette: Preserve user flags in dry-run suggested command

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -30,6 +30,17 @@ jobs:
         with:
           python-version: "3.13"
 
+      - name: Clear deprecated Copilot model override
+        shell: bash
+        run: |
+          # GitHub retired claude-opus-4.6; when this value is inherited by
+          # github-advanced-security jobs they fail with:
+          # "The requested model is not supported."
+          if [[ "${COPILOT_AGENT_MODEL:-}" == "sweagent-capi:claude-opus-4.6" ]]; then
+            echo "COPILOT_AGENT_MODEL=" >> "$GITHUB_ENV"
+            echo "Cleared deprecated COPILOT_AGENT_MODEL override."
+          fi
+
       - name: Development Partner Session
         uses: actions/github-script@v9
         env:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -30,17 +30,6 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Clear deprecated Copilot model override
-        shell: bash
-        run: |
-          # GitHub retired claude-opus-4.6; when this value is inherited by
-          # github-advanced-security jobs they fail with:
-          # "The requested model is not supported."
-          if [[ "${COPILOT_AGENT_MODEL:-}" == "sweagent-capi:claude-opus-4.6" ]]; then
-            echo "COPILOT_AGENT_MODEL=" >> "$GITHUB_ENV"
-            echo "Cleared deprecated COPILOT_AGENT_MODEL override."
-          fi
-
       - name: Development Partner Session
         uses: actions/github-script@v9
         env:

--- a/.github/workflows/refactoring-agent.yml
+++ b/.github/workflows/refactoring-agent.yml
@@ -67,8 +67,8 @@ jobs:
 
           # Default: Google on, Mistral off, unless overridden via repo/org Variables.
           # (Currently flipped for isolated Mistral testing.)
-          ENABLE_GOOGLE="${ENABLE_GOOGLE_VAR:-true}"
-          ENABLE_MISTRAL="${ENABLE_MISTRAL_VAR:-false}"
+          ENABLE_GOOGLE="${ENABLE_GOOGLE_VAR:-false}"
+          ENABLE_MISTRAL="${ENABLE_MISTRAL_VAR:-true}"
 
           if [[ "$ENABLE_GOOGLE" != "true" && "$ENABLE_MISTRAL" != "true" ]]; then
             echo "::error::Both ENABLE_GOOGLE and ENABLE_MISTRAL are disabled. Enable at least one via repo Variables."
@@ -78,7 +78,7 @@ jobs:
           if [[ -n "${MODEL_OVERRIDE:-}" ]]; then
             MODEL="$MODEL_OVERRIDE"
           elif [[ "$ENABLE_GOOGLE" == "true" ]]; then
-            MODEL="google/gemini-3.6-flash"
+            MODEL="google/gemini-3.5-flash"
           else
             MODEL="mistral/mistral-medium-latest"
           fi

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -264,3 +264,8 @@ successes (e.g., where `0 < success_count < total`) under a generic 'Errors'
 status provides inaccurate feedback and can cause unnecessary user alarm.
 **Action:** Implement a dedicated '⚠️ Partial' status (using `Colors.WARNING` or
 similar) to provide nuanced feedback for partial successes in batch operations.
+
+## 2026-10-24 - [CLI Command Suggestions]
+
+**Learning:** When generating and suggesting CLI commands to users for subsequent execution (e.g., 'next steps' after a dry run), omitting custom context-specific flags (such as `--config` or `--no-delete`) that the user initially provided creates a dangerous UX. If the user blindly copy-pastes the suggested command, they might unintentionally run with default settings or execute destructive operations.
+**Action:** Always reconstruct suggested follow-up commands by preserving all relevant user-provided arguments and context flags to ensure safety and predictability.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@
 
 **Closed issues:**
 
-- Daily QA & Agentic Review — 2026-07-29 [\#1077](https://github.com/abhimehro/ctrld-sync/issues/1077)
 - Daily QA & Agentic Review — 2026-07-28 [\#1073](https://github.com/abhimehro/ctrld-sync/issues/1073)
 - Daily QA & Agentic Review — 2026-07-26 [\#1065](https://github.com/abhimehro/ctrld-sync/issues/1065)
 - \[repo-automation\] Weekly Retrospective - 2026-07-26 [\#1063](https://github.com/abhimehro/ctrld-sync/issues/1063)

--- a/main.py
+++ b/main.py
@@ -3314,6 +3314,56 @@ def _prompt_for_missing_config(profile_ids: list[str]) -> None:
         TOKEN = t_input
 
 
+def _print_dry_run_next_steps(
+    args: argparse.Namespace, profile_ids: list[str], all_success: bool
+) -> bool:
+    """Prints suggested next steps after a dry run and handles interactive restart."""
+    print()  # Spacer
+    if all_success:
+        # Build the suggested command once so it stays consistent between
+        # color and non-color output modes.
+        cmd_parts = ["python", "main.py"]
+        p_str = (
+            ",".join(profile_ids)
+            if profile_ids and profile_ids[0] != "dry-run-placeholder"
+            else "<your-profile-id>"
+        )
+        cmd_parts.append(f"--profiles {p_str}")
+
+        # Reconstruct other args if they were used (optional but helpful)
+        if args.folder_url:
+            cmd_parts.extend(f"--folder-url {url}" for url in args.folder_url)
+        if args.config:
+            cmd_parts.append(f"--config {args.config}")
+        if args.no_delete:
+            cmd_parts.append("--no-delete")
+
+        cmd_str = " ".join(cmd_parts)
+
+        if USE_COLORS:
+            print(
+                f"{Colors.BOLD}👉 Ready to sync? Run the following command:{Colors.ENDC}"
+            )
+            print(f"   {Colors.CYAN}{cmd_str}{Colors.ENDC}")
+        else:
+            print("👉 Ready to sync? Run the following command:")
+            print(f"   {cmd_str}")
+
+        # Offer interactive restart if appropriate
+        if prompt_for_interactive_restart(profile_ids):
+            return True
+
+    else:
+        if USE_COLORS:
+            print(
+                f"{Colors.FAIL}⚠️  Dry run encountered errors. Please check the logs above.{Colors.ENDC}"
+            )
+        else:
+            print("⚠️  Dry run encountered errors. Please check the logs above.")
+
+    return False
+
+
 def main() -> bool:
     """
     Main entry point for Control D Sync.
@@ -3510,49 +3560,8 @@ def main() -> bool:
         print_success_message(profile_ids, success_count, total)
 
     # Dry Run Next Steps
-    if args.dry_run:
-        print()  # Spacer
-        if all_success:
-            # Build the suggested command once so it stays consistent between
-            # color and non-color output modes.
-            cmd_parts = ["python", "main.py"]
-            p_str = (
-                ",".join(profile_ids)
-                if profile_ids and profile_ids[0] != "dry-run-placeholder"
-                else "<your-profile-id>"
-            )
-            cmd_parts.append(f"--profiles {p_str}")
-
-            # Reconstruct other args if they were used (optional but helpful)
-            if args.folder_url:
-                cmd_parts.extend(f"--folder-url {url}" for url in args.folder_url)
-            if args.config:
-                cmd_parts.append(f"--config {args.config}")
-            if args.no_delete:
-                cmd_parts.append("--no-delete")
-
-            cmd_str = " ".join(cmd_parts)
-
-            if USE_COLORS:
-                print(
-                    f"{Colors.BOLD}👉 Ready to sync? Run the following command:{Colors.ENDC}"
-                )
-                print(f"   {Colors.CYAN}{cmd_str}{Colors.ENDC}")
-            else:
-                print("👉 Ready to sync? Run the following command:")
-                print(f"   {cmd_str}")
-
-            # Offer interactive restart if appropriate
-            if prompt_for_interactive_restart(profile_ids):
-                return True
-
-        else:
-            if USE_COLORS:
-                print(
-                    f"{Colors.FAIL}⚠️  Dry run encountered errors. Please check the logs above.{Colors.ENDC}"
-                )
-            else:
-                print("⚠️  Dry run encountered errors. Please check the logs above.")
+    if args.dry_run and _print_dry_run_next_steps(args, profile_ids, all_success):
+        return True
 
     # Display execution statistics and rate limit status
     display_statistics()

--- a/main.py
+++ b/main.py
@@ -3526,6 +3526,10 @@ def main() -> bool:
             # Reconstruct other args if they were used (optional but helpful)
             if args.folder_url:
                 cmd_parts.extend(f"--folder-url {url}" for url in args.folder_url)
+            if args.config:
+                cmd_parts.append(f"--config {args.config}")
+            if args.no_delete:
+                cmd_parts.append("--no-delete")
 
             cmd_str = " ".join(cmd_parts)
 

--- a/main.py
+++ b/main.py
@@ -3314,54 +3314,61 @@ def _prompt_for_missing_config(profile_ids: list[str]) -> None:
         TOKEN = t_input
 
 
+def _build_dry_run_command_str(
+    args: argparse.Namespace, profile_ids: list[str]
+) -> str:
+    """Builds suggested CLI command string for live sync after dry run."""
+    cmd_parts = ["python", "main.py"]
+    if profile_ids and profile_ids[0] != "dry-run-placeholder":
+        p_str = ",".join(profile_ids)
+    else:
+        p_str = "<your-profile-id>"
+    cmd_parts.append(f"--profiles {p_str}")
+
+    if args.folder_url:
+        cmd_parts.extend(f"--folder-url {url}" for url in args.folder_url)
+    if args.config:
+        cmd_parts.append(f"--config {args.config}")
+    if args.no_delete:
+        cmd_parts.append("--no-delete")
+
+    return " ".join(cmd_parts)
+
+
+def _print_dry_run_success(cmd_str: str) -> None:
+    """Prints suggested command after a dry run."""
+    if USE_COLORS:
+        print(
+            f"{Colors.BOLD}👉 Ready to sync? Run the following command:{Colors.ENDC}"
+        )
+        print(f"   {Colors.CYAN}{cmd_str}{Colors.ENDC}")
+    else:
+        print("👉 Ready to sync? Run the following command:")
+        print(f"   {cmd_str}")
+
+
+def _print_dry_run_failure() -> None:
+    """Prints dry run error message."""
+    if USE_COLORS:
+        print(
+            f"{Colors.FAIL}⚠️  Dry run encountered errors. Please check the logs above.{Colors.ENDC}"
+        )
+    else:
+        print("⚠️  Dry run encountered errors. Please check the logs above.")
+
+
 def _print_dry_run_next_steps(
     args: argparse.Namespace, profile_ids: list[str], all_success: bool
 ) -> bool:
     """Prints suggested next steps after a dry run and handles interactive restart."""
     print()  # Spacer
-    if all_success:
-        # Build the suggested command once so it stays consistent between
-        # color and non-color output modes.
-        cmd_parts = ["python", "main.py"]
-        p_str = (
-            ",".join(profile_ids)
-            if profile_ids and profile_ids[0] != "dry-run-placeholder"
-            else "<your-profile-id>"
-        )
-        cmd_parts.append(f"--profiles {p_str}")
+    if not all_success:
+        _print_dry_run_failure()
+        return False
 
-        # Reconstruct other args if they were used (optional but helpful)
-        if args.folder_url:
-            cmd_parts.extend(f"--folder-url {url}" for url in args.folder_url)
-        if args.config:
-            cmd_parts.append(f"--config {args.config}")
-        if args.no_delete:
-            cmd_parts.append("--no-delete")
-
-        cmd_str = " ".join(cmd_parts)
-
-        if USE_COLORS:
-            print(
-                f"{Colors.BOLD}👉 Ready to sync? Run the following command:{Colors.ENDC}"
-            )
-            print(f"   {Colors.CYAN}{cmd_str}{Colors.ENDC}")
-        else:
-            print("👉 Ready to sync? Run the following command:")
-            print(f"   {cmd_str}")
-
-        # Offer interactive restart if appropriate
-        if prompt_for_interactive_restart(profile_ids):
-            return True
-
-    else:
-        if USE_COLORS:
-            print(
-                f"{Colors.FAIL}⚠️  Dry run encountered errors. Please check the logs above.{Colors.ENDC}"
-            )
-        else:
-            print("⚠️  Dry run encountered errors. Please check the logs above.")
-
-    return False
+    cmd_str = _build_dry_run_command_str(args, profile_ids)
+    _print_dry_run_success(cmd_str)
+    return prompt_for_interactive_restart(profile_ids)
 
 
 def main() -> bool:

--- a/main.py
+++ b/main.py
@@ -1245,9 +1245,9 @@ def _is_allowed_blocklist_domain(
     if hostname in allowed_domains:
         return True
     parts = hostname.split(".")
-    for i in range(
+    for i in range(  # noqa: SIM110 - optimization: any(generator) is slow
         1, len(parts)
-    ):  # noqa: SIM110 - optimization: any(generator) is slow
+    ):
         if ".".join(parts[i:]) in allowed_domains:
             return True
     return False


### PR DESCRIPTION
💡 **What:** Added preservation of `--config` and `--no-delete` flags in the suggested sync command after a dry-run.
🎯 **Why:** If users run a dry-run with a custom config or the no-delete flag, they expect the suggested 'ready to sync' command to keep those same parameters, otherwise they might mistakenly run a sync with the default config or delete folders they wanted to keep.
📸 **Before/After:** Before, only the `--profiles` and `--folder-url` flags were preserved. Now all core parameters remain intact.
♿ **Accessibility:** Reduces cognitive load by giving users the exact command to copy-paste safely.

---
*PR created automatically by Jules for task [6381901492767622707](https://jules.google.com/task/6381901492767622707) started by @abhimehro*