### PR TITLE
🎨 Palette: Dim secondary hint in interactive restart prompt

### DIFF
--- a/main.py
+++ b/main.py
@@ -2830,8 +2830,8 @@ def sync_profile(
 # --------------------------------------------------------------------------- #
 def _get_interactive_restart_confirmation() -> bool:
     """Helper to prompt for and validate interactive restart confirmation."""
-    prompt_initial = f"{Colors.BOLD}🚀 Ready to launch? {Colors.ENDC}Press [Enter] to run now (or type 'n' / Ctrl+C to cancel)... "
-    prompt_reprompt = f"{Colors.BOLD}🚀 Ready to launch? {Colors.ENDC}Press [Enter] to run now (or type 'n' / Ctrl+C to cancel)... "
+    prompt_initial = f"{Colors.BOLD}🚀 Ready to launch? {Colors.ENDC}{Colors.DIM}Press [Enter] to run now (or type 'n' / Ctrl+C to cancel)... {Colors.ENDC}"
+    prompt_reprompt = f"{Colors.BOLD}🚀 Ready to launch? {Colors.ENDC}{Colors.DIM}Press [Enter] to run now (or type 'n' / Ctrl+C to cancel)... {Colors.ENDC}"
     cancel_msg = f"{Colors.WARNING}⚠️  Cancelled.{Colors.ENDC}"
     err_msg = f"{Colors.FAIL}❌ Unrecognized input. Please press Enter to continue, or 'n' to cancel.{Colors.ENDC}"
 


### PR DESCRIPTION
💡 What: Dimmed the secondary instruction text ("Press [Enter] to run now...") on the interactive restart prompt using `Colors.DIM`.

🎯 Why: Prevents bright colors from causing visual noise and establishes a clearer visual hierarchy between the primary action (the question) and the secondary follow-up instruction.

📸 Before/After: N/A (CLI visual formatting change)

♿ Accessibility: Reduced visual noise can help users focus on the primary call to action.

---
*PR created automatically by Jules for task [66136686992734411](https://jules.google.com/task/66136686992734411) started by @abhimehro*