### PR TITLE
Fix capsys assertions in test_main.py

### DIFF
--- a/test_main.py
+++ b/test_main.py
@@ -503,12 +503,12 @@ def test_get_validated_input_retry(monkeypatch, capsys):
 
     # Check output for error messages
     captured = capsys.readouterr()
-    assert "Value cannot be empty" in captured.out
+    assert "Value cannot be empty" in captured.err
     assert (
         "💡 Hint: Please type a value and press Enter, or press Ctrl+C/Ctrl+D to cancel."
-        in captured.out
+        in captured.err
     )
-    assert "Error message" in captured.out
+    assert "Error message" in captured.err
 
 
 # Case 12: get_password works with getpass
@@ -527,10 +527,10 @@ def test_get_password(monkeypatch, capsys):
     assert getpass_mock.call_count == 2
 
     captured = capsys.readouterr()
-    assert "Value cannot be empty" in captured.out
+    assert "Value cannot be empty" in captured.err
     assert (
         "💡 Hint: Please type a value and press Enter, or press Ctrl+C/Ctrl+D to cancel."
-        in captured.out
+        in captured.err
     )
 
 


### PR DESCRIPTION
What: Fixed failing tests `test_get_validated_input_retry` and `test_get_password` by asserting against `captured.err` instead of `captured.out`.\nWhy: The prompts for invalid input and empty values are now written to `sys.stderr`, causing the tests to fail when checking stdout.\nBefore: Tests failed asserting against `captured.out`.\nAfter: Tests pass asserting against `captured.err`.

---
*PR created automatically by Jules for task [2951172952961571929](https://jules.google.com/task/2951172952961571929) started by @abhimehro*