### PR TITLE
🎨 Palette: Improve visual hierarchy in interactive restart prompt

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -275,3 +275,7 @@ suggested command, they might unintentionally run with default settings or
 execute destructive operations. **Action:** Always reconstruct suggested
 follow-up commands by preserving all relevant user-provided arguments and
 context flags to ensure safety and predictability.
+
+## 2026-07-31 - Visual hierarchy in CLI prompts
+**Learning:** Found an opportunity to improve visual hierarchy in CLI prompts by utilizing `Colors.DIM` for secondary/optional text (hints). This makes it easier for users to scan the primary action required, reducing visual noise.
+**Action:** Use `Colors.DIM` to style secondary instructions in prompts such as `_get_interactive_restart_confirmation` in `main.py`.

--- a/main.py
+++ b/main.py
@@ -2830,8 +2830,8 @@ def sync_profile(
 # --------------------------------------------------------------------------- #
 def _get_interactive_restart_confirmation() -> bool:
     """Helper to prompt for and validate interactive restart confirmation."""
-    prompt_initial = f"{Colors.BOLD}🚀 Ready to launch? {Colors.ENDC}Press [Enter] to run now (or type 'n' / Ctrl+C to cancel)... "
-    prompt_reprompt = f"{Colors.BOLD}🚀 Ready to launch? {Colors.ENDC}Press [Enter] to run now (or type 'n' / Ctrl+C to cancel)... "
+    prompt_initial = f"{Colors.BOLD}🚀 Ready to launch? {Colors.ENDC}Press [Enter] to run now {Colors.DIM}(or type 'n' / Ctrl+C to cancel)...{Colors.ENDC} "
+    prompt_reprompt = f"{Colors.BOLD}🚀 Ready to launch? {Colors.ENDC}Press [Enter] to run now {Colors.DIM}(or type 'n' / Ctrl+C to cancel)...{Colors.ENDC} "
     cancel_msg = f"{Colors.WARNING}⚠️  Cancelled.{Colors.ENDC}"
     err_msg = f"{Colors.FAIL}❌ Unrecognized input. Please press Enter to continue, or 'n' to cancel.{Colors.ENDC}"
 


### PR DESCRIPTION
- What: Changed the secondary instructions in `_get_interactive_restart_confirmation` to use `Colors.DIM` styling and appended a learning about visual hierarchy to the `.jules/palette.md` journal.
- Why: To establish a clear visual hierarchy and reduce visual noise, making it easier for users to identify the primary required action.
- Before/After: Before, all instructional text was the same default color, which looked cluttered. After, the primary action ("Press [Enter] to run now") stands out, while the cancellation options are visually deemphasized.
- Accessibility: Reduces cognitive load and visual clutter for sighted users.

---
*PR created automatically by Jules for task [3465180968890478243](https://jules.google.com/task/3465180968890478243) started by @abhimehro*