### PR TITLE
🎨 Palette: Dim unfilled progress bar tracks for better visual hierarchy

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -283,3 +283,7 @@ context flags to ensure safety and predictability.
 ## 2026-08-01 - [Visual Hierarchy for Auto-Appended Hints]
 **Learning:** When auto-appending informative hints (like "(typing will be hidden)") to CLI prompts, appending them as plain text can cause them to blend in with the primary instruction, reducing visual hierarchy.
 **Action:** Use `Colors.DIM` (conditionally checking `USE_COLORS`) to style auto-appended secondary instructions, making them visually distinct from the main prompt while remaining accessible.
+
+## 2026-08-01 - [Visual Polish for Progress Bars]
+**Learning:** The unfilled portion of progress bars ("·" characters) can visually compete with the filled portion when rendered in the same color, reducing the scannability of the progress state.
+**Action:** Apply `Colors.DIM` to the unfilled portion of CLI progress bars and countdown timers to create better contrast and a more polished, intuitive visual hierarchy.

--- a/display.py
+++ b/display.py
@@ -350,7 +350,7 @@ def countdown_timer(seconds: int, message: str = "Waiting") -> None:
     for remaining in range(seconds, 0, -1):
         progress = (seconds - remaining + 1) / seconds
         filled = int(width * progress)
-        bar = "█" * filled + "·" * (width - filled)
+        bar = "█" * filled + f"{Colors.DIM}" + "·" * (width - filled) + f"{Colors.ENDC}{Colors.CYAN}"
         sys.stderr.write(
             f"\r\033[K{Colors.CYAN}⏳ {message}: [{bar}] {remaining:>{max_len}}s...{Colors.ENDC}"
         )
@@ -374,7 +374,7 @@ def render_progress_bar(
 
     progress = min(1.0, current / total)
     filled = int(width * progress)
-    bar = "█" * filled + "·" * (width - filled)
+    bar = "█" * filled + f"{Colors.DIM}" + "·" * (width - filled) + f"{Colors.ENDC}{Colors.CYAN}"
     percent = int(progress * 100)
 
     total_str = str(total)


### PR DESCRIPTION
💡 What: Added `Colors.DIM` to the unfilled track (`·`) of CLI progress bars and countdown timers in `display.py`.
🎯 Why: Improves visual hierarchy and contrast by reducing visual competition between the filled and unfilled parts of the progress bar.
♿ Accessibility: Enhances scannability for users reading terminal output.

---
*PR created automatically by Jules for task [4267899881629627756](https://jules.google.com/task/4267899881629627756) started by @abhimehro*