### PR TITLE
chore(devin): add environment blueprint as source-of-truth

### DIFF
--- a/.devin/blueprint.yaml
+++ b/.devin/blueprint.yaml
@@ -1,0 +1,30 @@
+# https://docs.devin.ai/onboard-devin/environment-yaml
+# One-time setup (e.g., install system tools, global CLIs).
+initialize:
+  - uses: github.com/astral-sh/setup-uv@v7
+    with:
+      enable-cache: true
+      cache-dependency-glob: uv.lock
+  - uses: github.com/actions/setup-python@v5
+    with:
+      python-version: "3.13"
+# Install project dependencies (runs during builds, surfaced to agent at session start).
+maintenance: |
+  uv sync --all-extras
+  uv run pre-commit install
+knowledge:
+  - name: test
+    contents: |
+      uv run pytest tests/ test_main.py -v
+  - name: lint
+    contents: |
+      uv run ruff check .
+      uv run mypy main.py models.py validation.py config.py display.py gh_client.py sync.py api_client.py cache.py fix_env.py
+  - name: format
+    contents: |
+      uv run ruff format --check .
+      uv run ruff format .
+  - name: run
+    contents: |
+      uv run python main.py --dry-run
+      Live runs require TOKEN and PROFILE environment variables.

--- a/.devin/blueprint.yaml
+++ b/.devin/blueprint.yaml
@@ -5,9 +5,7 @@ initialize:
     with:
       enable-cache: true
       cache-dependency-glob: uv.lock
-  - uses: github.com/actions/setup-python@v5
-    with:
-      python-version: "3.13"
+  - run: uv python install 3.13
 # Install project dependencies (runs during builds, surfaced to agent at session start).
 maintenance: |
   uv sync --all-extras
@@ -20,11 +18,15 @@ knowledge:
     contents: |
       uv run ruff check .
       uv run mypy main.py models.py validation.py config.py display.py gh_client.py sync.py api_client.py cache.py fix_env.py
-  - name: format
+  - name: format-check
     contents: |
       uv run ruff format --check .
+  - name: format
+    contents: |
       uv run ruff format .
   - name: run
     contents: |
       uv run python main.py --dry-run
+  - name: notes
+    contents: |
       Live runs require TOKEN and PROFILE environment variables.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 [Full Changelog](https://github.com/abhimehro/ctrld-sync/compare/v0.1.1...HEAD)
 
+**Added:**
+
+- Devin environment blueprint (`.devin/blueprint.yaml`) for reproducible agent sessions.
+
 **Security fixes:**
 
 - P1: SSRF - User-Controlled URLs with Outbound Requests [\#1024](https://github.com/abhimehro/ctrld-sync/issues/1024)


### PR DESCRIPTION
## Summary

Adds `.devin/blueprint.yaml` so the Devin environment configuration is version-controlled in GitHub alongside the repo. This mirrors the blueprint already saved in Devin's settings and provides an additional source of truth for reproducible sessions.

## What Changed and Why

- Added `.devin/blueprint.yaml` with:
  - `initialize` steps to install `uv` and Python 3.13
  - `maintenance` steps to sync dependencies and install pre-commit hooks
  - `knowledge` entries for test, lint, format, and dry-run commands

## How to Test or Verify

1. Check out this branch.
2. Run `uv sync --all-extras`.
3. Run `uv run pytest tests/ test_main.py -v` (396 tests should pass).
4. Run `uv run python main.py --dry-run`.

## Security Implications

- No secrets or credentials are introduced or exposed.
- Live runs still require `TOKEN` and `PROFILE` environment variables (not included in this file).

## Checklist

- [x] Branch follows naming convention
- [x] Commit message is clear and descriptive
- [x] No secrets, credentials, tokens, profiles, or `.env` files are included in this PR

Link to Devin session: https://app.devin.ai/sessions/fa057b747b8b4531a33096301ee91a51
Requested by: @abhimehro
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/ctrld-sync/pull/1108" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->