### PR TITLE
🎨 Palette: Add proactive hint to Profile ID prompt

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -287,3 +287,7 @@ context flags to ensure safety and predictability.
 ## 2026-08-01 - [Visual Polish for Progress Bars]
 **Learning:** The unfilled portion of progress bars ("·" characters) can visually compete with the filled portion when rendered in the same color, reducing the scannability of the progress state.
 **Action:** Apply `Colors.DIM` to the unfilled portion of CLI progress bars and countdown timers to create better contrast and a more polished, intuitive visual hierarchy.
+
+## 2026-08-02 - [Visual Hierarchy for Proactive Hints]
+**Learning:** When prompting for inputs that allow multiple values, waiting until the user encounters an error to explain the format (e.g., "comma-separate for multiple") is a poor experience. However, appending this hint in plain text can clutter the primary instruction.
+**Action:** Include proactive input format hints directly in the prompt, but style them with `Colors.DIM` to maintain a clear visual hierarchy where the primary action remains in focus while the hint is available but unobtrusive.

--- a/main.py
+++ b/main.py
@@ -439,7 +439,7 @@ def _prompt_for_missing_config(profile_ids: list[str]) -> None:
 
         print()
         p_input = get_validated_input(
-            f"{Colors.BOLD}👤 Enter Control D Profile ID:{Colors.ENDC} ",
+            f"{Colors.BOLD}👤 Enter Control D Profile ID {Colors.DIM}(comma-separate for multiple){Colors.ENDC}: ",
             validate_profile_input,
             "Invalid ID(s) or URL(s). Must be a valid Profile ID or a Control D Profile URL. Comma-separate for multiple.",
         )


### PR DESCRIPTION
**💡 What:** Added a proactive "(comma-separate for multiple)" hint to the Profile ID prompt in `main.py`, styled with `Colors.DIM`.
**🎯 Why:** Previously, users only learned they could input multiple comma-separated Profile IDs if they triggered a validation error. Adding this hint proactively improves discoverability while using `Colors.DIM` ensures it doesn't distract from the primary prompt.
**📸 Before:** `👤 Enter Control D Profile ID: `
**📸 After:** `👤 Enter Control D Profile ID (comma-separate for multiple): `
**♿ Accessibility:** N/A - text remains readable and screen readers will announce the hint naturally.

---
*PR created automatically by Jules for task [3420261716897283596](https://jules.google.com/task/3420261716897283596) started by @abhimehro*