### PR TITLE
🎨 Palette: Add proactive formatting hint to Profile ID prompt

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-03-05 - Proactive CLI Input Hints
+**Learning:** When a CLI input field supports complex or multiple values (like comma-separated lists), users often make mistakes because they don't know the format until they fail validation.
+**Action:** Proactively include a formatting hint directly in the prompt (styled with `Colors.DIM`) to educate the user before they make a mistake, rather than relying solely on validation error messages.

--- a/display.py
+++ b/display.py
@@ -361,7 +361,12 @@ def countdown_timer(seconds: int, message: str = "Waiting") -> None:
     for remaining in range(seconds, 0, -1):
         progress = (seconds - remaining + 1) / seconds
         filled = int(width * progress)
-        bar = "█" * filled + f"{Colors.DIM}" + "·" * (width - filled) + f"{Colors.ENDC}{Colors.CYAN}"
+        bar = (
+            "█" * filled
+            + f"{Colors.DIM}"
+            + "·" * (width - filled)
+            + f"{Colors.ENDC}{Colors.CYAN}"
+        )
         sys.stderr.write(
             f"\r\033[K{Colors.CYAN}⏳ {message}: [{bar}] {remaining:>{max_len}}s...{Colors.ENDC}"
         )
@@ -386,7 +391,12 @@ def render_progress_bar(
 
     progress = min(1.0, current / total)
     filled = int(width * progress)
-    bar = "█" * filled + f"{Colors.DIM}" + "·" * (width - filled) + f"{Colors.ENDC}{Colors.CYAN}"
+    bar = (
+        "█" * filled
+        + f"{Colors.DIM}"
+        + "·" * (width - filled)
+        + f"{Colors.ENDC}{Colors.CYAN}"
+    )
     percent = int(progress * 100)
 
     total_str = str(total)

--- a/main.py
+++ b/main.py
@@ -439,7 +439,7 @@ def _prompt_for_missing_config(profile_ids: list[str]) -> None:
 
         print()
         p_input = get_validated_input(
-            f"{Colors.BOLD}👤 Enter Control D Profile ID:{Colors.ENDC} ",
+            f"{Colors.BOLD}👤 Enter Control D Profile ID {Colors.DIM}(comma-separated for multiple){Colors.ENDC}: ",
             validate_profile_input,
             "Invalid ID(s) or URL(s). Must be a valid Profile ID or a Control D Profile URL. Comma-separate for multiple.",
         )


### PR DESCRIPTION
What: Added a formatting hint directly in the prompt for Profile IDs.
Why: Users often don't know the format for complex inputs (like comma-separated values) until they fail validation.
Before/After: Before, the hint about comma-separation was only in the error message. After, it's displayed proactively in the prompt.

---
*PR created automatically by Jules for task [10654655331634884519](https://jules.google.com/task/10654655331634884519) started by @abhimehro*