### PR TITLE
🎨 Palette: Add proactive hint for profile ID input

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -287,3 +287,7 @@ context flags to ensure safety and predictability.
 ## 2026-08-01 - [Visual Polish for Progress Bars]
 **Learning:** The unfilled portion of progress bars ("·" characters) can visually compete with the filled portion when rendered in the same color, reducing the scannability of the progress state.
 **Action:** Apply `Colors.DIM` to the unfilled portion of CLI progress bars and countdown timers to create better contrast and a more polished, intuitive visual hierarchy.
+
+## 2026-08-03 - [Proactive CLI Input Hints]
+**Learning:** When a CLI input field supports complex or multiple values (e.g., comma-separated), relying solely on validation errors to educate the user creates a poor UX.
+**Action:** Proactively include a formatting hint directly in the prompt (styled with `Colors.DIM`) to guide the user before they submit their input.

--- a/display.py
+++ b/display.py
@@ -361,7 +361,12 @@ def countdown_timer(seconds: int, message: str = "Waiting") -> None:
     for remaining in range(seconds, 0, -1):
         progress = (seconds - remaining + 1) / seconds
         filled = int(width * progress)
-        bar = "█" * filled + f"{Colors.DIM}" + "·" * (width - filled) + f"{Colors.ENDC}{Colors.CYAN}"
+        bar = (
+            "█" * filled
+            + f"{Colors.DIM}"
+            + "·" * (width - filled)
+            + f"{Colors.ENDC}{Colors.CYAN}"
+        )
         sys.stderr.write(
             f"\r\033[K{Colors.CYAN}⏳ {message}: [{bar}] {remaining:>{max_len}}s...{Colors.ENDC}"
         )
@@ -386,7 +391,12 @@ def render_progress_bar(
 
     progress = min(1.0, current / total)
     filled = int(width * progress)
-    bar = "█" * filled + f"{Colors.DIM}" + "·" * (width - filled) + f"{Colors.ENDC}{Colors.CYAN}"
+    bar = (
+        "█" * filled
+        + f"{Colors.DIM}"
+        + "·" * (width - filled)
+        + f"{Colors.ENDC}{Colors.CYAN}"
+    )
     percent = int(progress * 100)
 
     total_str = str(total)

--- a/main.py
+++ b/main.py
@@ -439,7 +439,7 @@ def _prompt_for_missing_config(profile_ids: list[str]) -> None:
 
         print()
         p_input = get_validated_input(
-            f"{Colors.BOLD}👤 Enter Control D Profile ID:{Colors.ENDC} ",
+            f"{Colors.BOLD}👤 Enter Control D Profile ID:{Colors.ENDC} {Colors.DIM}(comma-separated for multiple){Colors.ENDC} ",
             validate_profile_input,
             "Invalid ID(s) or URL(s). Must be a valid Profile ID or a Control D Profile URL. Comma-separate for multiple.",
         )


### PR DESCRIPTION
💡 What: Added a proactive `(comma-separated for multiple)` hint to the Control D Profile ID input prompt.
🎯 Why: To prevent users from relying on validation errors to learn the accepted format.
📸 Before/After: Visual hint is styled with `Colors.DIM` so it does not distract from the main prompt.
♿ Accessibility: Reduces cognitive load and prevents unnecessary validation failures.

---
*PR created automatically by Jules for task [11464228212968423674](https://jules.google.com/task/11464228212968423674) started by @abhimehro*