### PR TITLE
🎨 Palette: Fix CLI grammatical pluralization in success message

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -291,3 +291,7 @@ context flags to ensure safety and predictability.
 ## 2026-08-02 - [Visual Hierarchy for Proactive Hints]
 **Learning:** When prompting for inputs that allow multiple values, waiting until the user encounters an error to explain the format (e.g., "comma-separate for multiple") is a poor experience. However, appending this hint in plain text can clutter the primary instruction.
 **Action:** Include proactive input format hints directly in the prompt, but style them with `Colors.DIM` to maintain a clear visual hierarchy where the primary action remains in focus while the hint is available but unobtrusive.
+
+## 2026-08-04 - [Grammatical Polish in Success Messages]
+**Learning:** Hardcoding plural strings (like "profile(s)") can lead to poor grammar when counts evaluate to exactly 1.
+**Action:** Use `pluralize` to dynamically correct grammar in CLI output to improve text polish and reduce cognitive load.

--- a/display.py
+++ b/display.py
@@ -718,9 +718,8 @@ def _print_success_text(all_success: bool, success_count: int, total: int) -> No
         ]
         chosen_msg = secrets.choice(success_msgs)
     else:
-        chosen_msg = (
-            f"⚠️  Synced {success_count} out of {total} profile(s). Check errors above."
-        )
+        profile_word = pluralize(total, "profile")
+        chosen_msg = f"⚠️  Synced {success_count} out of {total} {profile_word}. Check errors above."
 
     if USE_COLORS:
         color = Colors.GREEN if all_success else Colors.WARNING


### PR DESCRIPTION
💡 What: Replaced static "profile(s)" string with dynamic pluralization in `display.py`.
🎯 Why: Using static plural nouns creates a grammatically disjointed user experience. Dynamic pluralization improves text polish.
📸 Before/After: Before: `1 profile(s)`. After: `1 profile`.
♿ Accessibility: Text polish reduces cognitive load for all users.

---
*PR created automatically by Jules for task [2115213646429672698](https://jules.google.com/task/2115213646429672698) started by @abhimehro*