### PR TITLE
🎨 Palette: Grammatical Polish for hardcoded (s)

### DIFF
--- a/main.py
+++ b/main.py
@@ -441,7 +441,7 @@ def _prompt_for_missing_config(profile_ids: list[str]) -> None:
         p_input = get_validated_input(
             f"{Colors.BOLD}👤 Enter Control D Profile ID {Colors.DIM}(comma-separate for multiple){Colors.ENDC}: ",
             validate_profile_input,
-            "Invalid ID(s) or URL(s). Must be a valid Profile ID or a Control D Profile URL. Comma-separate for multiple.",
+            "Invalid ID or URL. Must be a valid Profile ID or a Control D Profile URL. Comma-separate for multiple.",
         )
         profile_ids.extend(
             [extract_profile_id(p) for p in p_input.split(",") if p.strip()]
@@ -530,7 +530,7 @@ def parse_args() -> argparse.Namespace:
         "--profiles", help="Comma-separated list of profile IDs", default=None
     )
     parser.add_argument(
-        "--folder-url", action="append", help="Folder JSON URL(s)", default=None
+        "--folder-url", action="append", help="Folder JSON URL (repeatable)", default=None
     )
     parser.add_argument("--dry-run", action="store_true", help="Plan only")
     parser.add_argument(


### PR DESCRIPTION
💡 What: Removed hardcoded `(s)` from CLI prompts and help text.
🎯 Why: Using `(s)` creates awkward phrasing. Replaced with more precise wording.
📸 Before/After: 'Invalid ID(s) or URL(s)' -> 'Invalid ID or URL'. 'Folder JSON URL(s)' -> 'Folder JSON URL (repeatable)'.

---
*PR created automatically by Jules for task [519408625819160365](https://jules.google.com/task/519408625819160365) started by @abhimehro*