### PR TITLE
🎨 Palette: Improve error message grammar for comma-separated inputs

### DIFF
--- a/main.py
+++ b/main.py
@@ -441,7 +441,7 @@ def _prompt_for_missing_config(profile_ids: list[str]) -> None:
         p_input = get_validated_input(
             f"{Colors.BOLD}👤 Enter Control D Profile ID {Colors.DIM}(comma-separate for multiple){Colors.ENDC}: ",
             validate_profile_input,
-            "Invalid ID or URL. Must be a valid Profile ID or a Control D Profile URL. Comma-separate for multiple.",
+            "Invalid ID(s) or URL(s). Must be valid Profile ID(s) or Control D Profile URL(s). Comma-separate for multiple.",
         )
         profile_ids.extend(
             [extract_profile_id(p) for p in p_input.split(",") if p.strip()]


### PR DESCRIPTION
What: Changed 'ID' and 'URL' to 'ID(s)' and 'URL(s)' in the profile ID interactive prompt error message. Why: The input field explicitly encourages multiple comma-separated values, so forcing singular nouns in the error message created a semantic mismatch. Before: 'Invalid ID or URL...' After: 'Invalid ID(s) or URL(s)...'

---
*PR created automatically by Jules for task [16803565891253319545](https://jules.google.com/task/16803565891253319545) started by @abhimehro*