### PR TITLE
chore: auto-format files with ruff

### DIFF
--- a/.github/aw/imports/github/gh-aw/94662b1dee8ce96c876ba9f33b3ab8be32de82a4/.github_workflows_shared_trending-charts-simple.md
+++ b/.github/aw/imports/github/gh-aw/94662b1dee8ce96c876ba9f33b3ab8be32de82a4/.github_workflows_shared_trending-charts-simple.md
@@ -47,8 +47,8 @@ import json
 from datetime import datetime
 
 # Append data point
-with open('/tmp/gh-aw/cache-memory/trending/<metric>/history.jsonl', 'a') as f:
-    f.write(json.dumps({"timestamp": datetime.now().isoformat(), "value": 42}) + '\n')
+with open("/tmp/gh-aw/cache-memory/trending/<metric>/history.jsonl", "a") as f:
+    f.write(json.dumps({"timestamp": datetime.now().isoformat(), "value": 42}) + "\n")
 ```
 
 ## Generate Charts
@@ -58,16 +58,16 @@ import pandas as pd
 import matplotlib.pyplot as plt
 import seaborn as sns
 
-df = pd.read_json('history.jsonl', lines=True)
-df['date'] = pd.to_datetime(df['timestamp']).dt.date
+df = pd.read_json("history.jsonl", lines=True)
+df["date"] = pd.to_datetime(df["timestamp"]).dt.date
 
 sns.set_style("whitegrid")
 fig, ax = plt.subplots(figsize=(12, 7), dpi=300)
-df.groupby('date')['value'].mean().plot(ax=ax, marker='o')
-ax.set_title('Trend', fontsize=16, fontweight='bold')
+df.groupby("date")["value"].mean().plot(ax=ax, marker="o")
+ax.set_title("Trend", fontsize=16, fontweight="bold")
 plt.xticks(rotation=45)
 plt.tight_layout()
-plt.savefig('/tmp/gh-aw/python/charts/trend.png', dpi=300, bbox_inches='tight')
+plt.savefig("/tmp/gh-aw/python/charts/trend.png", dpi=300, bbox_inches="tight")
 ```
 
 ## Best Practices

--- a/.github/copilot/instructions/api-performance.md
+++ b/.github/copilot/instructions/api-performance.md
@@ -95,6 +95,7 @@ Test individual API operations in isolation:
 ```python
 # Measure single API call latency
 import time
+
 start = time.time()
 response = _api_get(client, f"{API_BASE}/{profile_id}")
 print(f"GET latency: {time.time() - start:.3f}s")
@@ -232,10 +233,7 @@ Simulate rate limit scenarios:
 ```python
 # Mock 429 response in tests
 mock_response.status_code = 429
-mock_response.headers = {
-    "Retry-After": "5",
-    "X-RateLimit-Remaining": "0"
-}
+mock_response.headers = {"Retry-After": "5", "X-RateLimit-Remaining": "0"}
 
 # Verify retry logic respects Retry-After
 # See tests/test_rate_limit.py for examples

--- a/.github/copilot/instructions/api-retry-strategy.md
+++ b/.github/copilot/instructions/api-retry-strategy.md
@@ -29,7 +29,8 @@ timing to spread load.
 
 ```python
 import random
-wait_time = (delay * (2 ** attempt)) * (0.5 + random.random())
+
+wait_time = (delay * (2**attempt)) * (0.5 + random.random())
 ```
 
 This adds ±50% randomness: a 4s backoff becomes 2-6s range.

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -56,8 +56,10 @@ Add to `main.py` for function-level timing:
 import time
 from functools import wraps
 
+
 def timed(func):
     """Decorator to measure and log execution time."""
+
     @wraps(func)
     def wrapper(*args, **kwargs):
         start = time.perf_counter()
@@ -65,6 +67,7 @@ def timed(func):
         elapsed = time.perf_counter() - start
         log.info(f"⏱️  {func.__name__} completed in {elapsed:.2f}s")
         return result
+
     return wrapper
 ```
 
@@ -94,19 +97,19 @@ def example_sync_workflow():
     # Your actual folder fetching logic here
     folder_data_list = []  # Results from concurrent futures
     t2 = time.perf_counter()
-    log.info(f"⏱️  Fetched {len(folder_data_list)} folders in {t2-t1:.2f}s")
+    log.info(f"⏱️  Fetched {len(folder_data_list)} folders in {t2 - t1:.2f}s")
 
     # Stage 2: Delete folders
     # Your actual folder deletion logic here
     t3 = time.perf_counter()
-    log.info(f"⏱️  Deleted folders in {t3-t2:.2f}s")
+    log.info(f"⏱️  Deleted folders in {t3 - t2:.2f}s")
 
     # Stage 3: Push rules
     # Your actual rule pushing logic here
     t4 = time.perf_counter()
-    log.info(f"⏱️  Pushed rules in {t4-t3:.2f}s")
+    log.info(f"⏱️  Pushed rules in {t4 - t3:.2f}s")
 
-    log.info(f"⏱️  TOTAL sync time: {t4-t0:.2f}s")
+    log.info(f"⏱️  TOTAL sync time: {t4 - t0:.2f}s")
 ```
 
 **Why this matters:** Without baseline numbers, every optimization is a guess.
@@ -126,6 +129,7 @@ Add a call counter to your API wrapper:
 ```python
 import threading
 
+
 class APICallTracker:
     def __init__(self):
         self.calls = {"GET": 0, "POST": 0, "DELETE": 0}
@@ -139,12 +143,15 @@ class APICallTracker:
         total = sum(self.calls.values())
         return f"API calls: {total} total ({', '.join(f'{k}:{v}' for k, v in self.calls.items())})"
 
+
 # Global tracker
 api_tracker = APICallTracker()
+
 
 def _api_get(client, url, **kwargs):
     api_tracker.record("GET")
     # existing implementation
+
 
 # At end of sync:
 log.info(api_tracker.summary())
@@ -170,6 +177,7 @@ import time
 import pytest
 from main import push_rules
 
+
 @pytest.mark.benchmark
 def test_push_rules_benchmark_10k():
     """Benchmark pushing 10,000 rules."""
@@ -186,6 +194,7 @@ def test_push_rules_benchmark_10k():
         Placeholder HTTP client for benchmarking example.
         Replace with your real client or test fixture that matches push_rules expectations.
         """
+
         pass
 
     mock_client = DummyClient()

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ https://controld.com/dashboard/profiles/741861frakbm/filters
 
 3. **Configure secrets** Create a `.env` file (or set GitHub secrets) with:
 
-   ```py
+   ```env
    TOKEN=your_control_d_api_token
    PROFILE=your_profile_id  # or comma-separated list of profile ids (e.g. your_id_1,your_id_2)
    ```

--- a/main.py
+++ b/main.py
@@ -530,7 +530,10 @@ def parse_args() -> argparse.Namespace:
         "--profiles", help="Comma-separated list of profile IDs", default=None
     )
     parser.add_argument(
-        "--folder-url", action="append", help="Folder JSON URL (repeatable)", default=None
+        "--folder-url",
+        action="append",
+        help="Folder JSON URL (repeatable)",
+        default=None,
     )
     parser.add_argument("--dry-run", action="store_true", help="Plan only")
     parser.add_argument(


### PR DESCRIPTION
### What
Applied automated formatting fixes using `ruff-format` and corrected language tags in documentation blocks to avoid unintentional formatting issues.

### Why
To maintain consistent code style and adhere to project standards, ensuring that auto-formatters properly interpret `.env` blocks.

### Before/After
Formatting adjustments applied to Python files and Markdown documentation. Specifically, changed ````py``` to ````env``` in `README.md` to prevent the environment variable examples from being malformed by the Python formatter.

---
*PR created automatically by Jules for task [18237950225122303350](https://jules.google.com/task/18237950225122303350) started by @abhimehro*