### PR TITLE
refactor(config): split _validate_config into per-section helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 [Full Changelog](https://github.com/abhimehro/ctrld-sync/compare/v0.1.1...HEAD)
 
+**Changed:**
+
+- Refactored `config.py` validation flow by splitting `_validate_config` into per-section helpers and named predicates while preserving behavior and error messages. [\#1095](https://github.com/abhimehro/ctrld-sync/issues/1095)
+
 **Security fixes:**
 
 - P1: SSRF - User-Controlled URLs with Outbound Requests [\#1024](https://github.com/abhimehro/ctrld-sync/issues/1024)

--- a/config.py
+++ b/config.py
@@ -98,6 +98,64 @@ def get_default_config() -> dict:
     }
 
 
+def _is_invalid_url(url: object) -> bool:
+    return not isinstance(url, str) or not url.startswith("https://")
+
+
+def _is_invalid_name(name: object) -> bool:
+    if not name:
+        return False
+    if not isinstance(name, str):
+        return True
+    return not name.strip()
+
+
+def _is_invalid_positive_int(val: object) -> bool:
+    if val is None:
+        return False
+    if not isinstance(val, int):
+        return True
+    return val <= 0
+
+
+def _validate_folders(folders: object) -> None:
+    if not isinstance(folders, list) or not folders:
+        raise ValueError("'folders' must be a non-empty list.")
+    for i, entry in enumerate(folders):
+        _validate_folder_entry(entry, i)
+
+
+def _validate_folder_entry(entry: object, index: int) -> None:
+    if not isinstance(entry, dict):
+        raise ValueError(
+            f"folders[{index}] must be a mapping, got {type(entry).__name__}."
+        )
+    url = entry.get("url", "")
+    if _is_invalid_url(url):
+        raise ValueError(
+            f"folders[{index}]: 'url' must be an https:// string (got {url!r})."
+        )
+    name = entry.get("name", "")
+    if _is_invalid_name(name):
+        raise ValueError(f"folders[{index}]: 'name' must be a non-empty string.")
+    action = entry.get("action")
+    if action is not None and action not in ("block", "allow"):
+        raise ValueError(
+            f"folders[{index}]: 'action' must be 'block' or 'allow' (got {action!r})."
+        )
+
+
+def _validate_settings(settings: object) -> None:
+    if not isinstance(settings, dict):
+        raise ValueError("'settings' must be a mapping.")
+    for key in ("batch_size", "delete_workers", "max_retries"):
+        val = settings.get(key)
+        if _is_invalid_positive_int(val):
+            raise ValueError(
+                f"settings.{key} must be a positive integer (got {val!r})."
+            )
+
+
 def _validate_config(config: dict) -> None:
     """
     Validate a loaded configuration dict and raise ValueError on the first problem.
@@ -111,41 +169,9 @@ def _validate_config(config: dict) -> None:
     """
     if "folders" not in config:
         raise ValueError("Configuration is missing the required 'folders' key.")
-
-    folders = config["folders"]
-    if not isinstance(folders, list) or not folders:
-        raise ValueError("'folders' must be a non-empty list.")
-
-    for i, entry in enumerate(folders):
-        if not isinstance(entry, dict):
-            raise ValueError(
-                f"folders[{i}] must be a mapping, got {type(entry).__name__}."
-            )
-        url = entry.get("url", "")
-        if not isinstance(url, str) or not url.startswith("https://"):
-            raise ValueError(
-                f"folders[{i}]: 'url' must be an https:// string (got {url!r})."
-            )
-        name = entry.get("name", "")
-        if name and (not isinstance(name, str) or not name.strip()):
-            raise ValueError(f"folders[{i}]: 'name' must be a non-empty string.")
-        action = entry.get("action")
-        if action is not None and action not in ("block", "allow"):
-            raise ValueError(
-                f"folders[{i}]: 'action' must be 'block' or 'allow' (got {action!r})."
-            )
-
+    _validate_folders(config["folders"])
     _validate_allowed_blocklist_domains(config.get("allowed_blocklist_domains"))
-
-    settings = config.get("settings", {})
-    if not isinstance(settings, dict):
-        raise ValueError("'settings' must be a mapping.")
-    for key in ("batch_size", "delete_workers", "max_retries"):
-        val = settings.get(key)
-        if val is not None and (not isinstance(val, int) or val <= 0):
-            raise ValueError(
-                f"settings.{key} must be a positive integer (got {val!r})."
-            )
+    _validate_settings(config.get("settings", {}))
 
 
 def _read_config_yaml(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -265,3 +265,106 @@ def test_config_yaml_example_is_valid():
     cfg = main.load_config(config_path=str(example))
     assert "folders" in cfg
     assert len(cfg["folders"]) > 0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Characterization tests for _validate_config behavior
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "cfg, expected",
+    [
+        ({}, "Configuration is missing the required 'folders' key."),
+        ({"folders": None}, "'folders' must be a non-empty list."),
+        ({"folders": []}, "'folders' must be a non-empty list."),
+        ({"folders": "x"}, "'folders' must be a non-empty list."),
+        ({"folders": ["x"]}, "folders[0] must be a mapping, got str."),
+        (
+            {"folders": [{}]},
+            "folders[0]: 'url' must be an https:// string (got '').",
+        ),
+        # ordering: folders error must win over a broken settings block
+        (
+            {"folders": [{}], "settings": "bad"},
+            "folders[0]: 'url' must be an https:// string (got '').",
+        ),
+        # ordering: allowed_blocklist_domains must be checked before settings
+        (
+            {
+                "folders": [{"url": "https://e.com/f.json"}],
+                "allowed_blocklist_domains": "nope",
+                "settings": "bad",
+            },
+            "'allowed_blocklist_domains' must be a list.",
+        ),
+        (
+            {"folders": [{"url": "https://e.com/f.json"}], "settings": None},
+            "'settings' must be a mapping.",
+        ),
+    ],
+)
+def test_validate_config_exact_error_messages(cfg, expected):
+    with pytest.raises(ValueError) as exc:
+        main._validate_config(cfg)
+    assert str(exc.value) == expected
+
+
+@pytest.mark.parametrize("name", ["", None, 0, []])
+def test_validate_config_falsy_name_is_accepted(name):
+    """Falsy `name` short-circuits the truthiness gate — preserved quirk."""
+    main._validate_config({"folders": [{"url": "https://e.com/f.json", "name": name}]})
+
+
+def test_validate_config_action_null_is_accepted():
+    """`action: null` is accepted by the `is not None` gate."""
+    main._validate_config(
+        {"folders": [{"url": "https://e.com/f.json", "action": None}]}
+    )
+
+
+def test_validate_config_settings_empty_dict_is_accepted():
+    main._validate_config(
+        {"folders": [{"url": "https://e.com/f.json"}], "settings": {}}
+    )
+
+
+def test_validate_config_settings_bool_true_for_batch_size_is_accepted():
+    """`bool` passes `isinstance(True, int)` — preserved quirk."""
+    main._validate_config(
+        {
+            "folders": [{"url": "https://e.com/f.json"}],
+            "settings": {"batch_size": True},
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    "allowed_blocklist_domains, expected",
+    [
+        (None, None),
+        (
+            "nope",
+            "'allowed_blocklist_domains' must be a list.",
+        ),
+        (
+            [""],
+            "allowed_blocklist_domains[0]: must be a non-empty string (got '').",
+        ),
+        (
+            [123],
+            "allowed_blocklist_domains[0]: must be a non-empty string (got 123).",
+        ),
+    ],
+)
+def test_validate_config_allowed_blocklist_domains(allowed_blocklist_domains, expected):
+    cfg = {
+        "folders": [{"url": "https://e.com/f.json"}],
+        "allowed_blocklist_domains": allowed_blocklist_domains,
+    }
+    if expected is None:
+        main._validate_config(cfg)  # must not raise
+    else:
+        with pytest.raises(ValueError) as exc:
+            main._validate_config(cfg)
+        assert str(exc.value) == expected

--- a/tests/test_ssrf_protection.py
+++ b/tests/test_ssrf_protection.py
@@ -124,4 +124,5 @@ def test_folder_url_broken_discovered_config_falls_back(tmp_path, monkeypatch):
     assert urls == ["https://raw.githubusercontent.com/test/file.json"]
     assert cfg is None
     # Fallback to defaults means the GitHub-only allowlist is active again.
-    assert main._ALLOWED_BLOCKLIST_DOMAINS == main.DEFAULT_ALLOWED_BLOCKLIST_DOMAINS
+    # main._ALLOWED_BLOCKLIST_DOMAINS is provided by a runtime __getattr__ hook.
+    assert main._ALLOWED_BLOCKLIST_DOMAINS == main.DEFAULT_ALLOWED_BLOCKLIST_DOMAINS  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

Closes abhimehro/ctrld-sync#1095

Splits `config.py:_validate_config` into focused, private helpers while preserving exact error messages and validation order. The refactor targets the CodeScene `Bumpy Road` critical finding and advisory `Complex Method`/`Complex Conditional`/`Many Conditionals` findings on `config.py`.

### What Changed and Why

* Extracted per-section helpers from `_validate_config`:
  * `_validate_folders`
  * `_validate_folder_entry`
  * `_validate_settings`
* Added named predicates for the three complex conditionals:
  * `_is_invalid_url`
  * `_is_invalid_name`
  * `_is_invalid_positive_int`
* Kept `_validate_config` as a small orchestrator with its original name, signature, and docstring.
* Preserved all `ValueError` messages and the validation order (`folders` → `allowed_blocklist_domains` → `settings`).
* Added table-driven characterization tests asserting exact error strings and preserved quirks (falsy `name`, `action: null`, `bool` as `int` in settings).
* Added `allowed_blocklist_domains` coverage via `_validate_config`.
* Added a one-line `# type: ignore` in `tests/test_ssrf_protection.py` so `mypy .` stays clean with `main.py`'s runtime `__getattr__` hook.

### Verification

* `uv run ruff check .` — clean
* `uv run mypy .` — clean
* `uv run pytest -q` — 416 passed, 2 subtests passed
* `uv run pytest --cov -q` — 69.13% coverage (≥ 55% required)
* `uv run ruff check --select C901 config.py` — clean
* `uv run python -c "import config; config._validate_config(config.get_default_config()); print('ok')"` — ok

### CodeScene Delta

* `config.py` Code Health: **8.41 → 9.10**
* 4 Quality Gates Passed
* Improved categories: `Complex Method`, `Complex Conditional`, `Bumpy Road Ahead`, `Overall Code Complexity`

## Security Implications

* No secrets or credentials are introduced or exposed.
* Validation strictness is unchanged; all existing error paths and ordering are preserved.

Link to Devin session: [https://app.devin.ai/sessions/4d6ff1733e0946298e766ef33c97d486](<https://app.devin.ai/sessions/4d6ff1733e0946298e766ef33c97d486>)<br>Requested by: @abhimehro

---

![Open in Devin Review](https://camo.githubusercontent.com/a4be08b8baaff58c5f163b8bbf073f8cdff8e3a6c7e2f554b621f61ab1557d7e/68747470733a2f2f7374617469632e646576696e2e61692f6173736574732f67682d6f70656e2d696e2d646576696e2d7265766965772d6c696768742e7376673f763d31)