### PR TITLE
refactor(display): simplify print_plan_details plan rendering logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 [Full Changelog](https://github.com/abhimehro/ctrld-sync/compare/v0.1.1...HEAD)
 
+**Changed:**
+
+- Refactored `display.py` dry-run plan rendering into focused `_resolve_folder_action` and `_format_*` helpers, lowering cyclomatic complexity while preserving exact CLI output and color behavior. [\#1143](https://github.com/abhimehro/ctrld-sync/pull/1143)
+
 **Security fixes:**
 
 - P1: SSRF - User-Controlled URLs with Outbound Requests [\#1024](https://github.com/abhimehro/ctrld-sync/issues/1024)

--- a/display.py
+++ b/display.py
@@ -255,27 +255,78 @@ def pluralize(count: int, singular: str, plural: str | None = None) -> str:
     return singular if count == 1 else plural
 
 
-def _get_action_text(folder: PlanFolderEntry) -> str:
-    """Determine the action label (Block/Allow/Mixed) for a given folder."""
+def _resolve_folder_action(folder: PlanFolderEntry) -> tuple[str, str, str]:
+    """Return (label, icon, color_attr_name) for a folder.
+
+    Does not evaluate ``USE_COLORS`` or touch ``Colors`` values; the color
+    attribute name is resolved at presentation time so tests that patch
+    ``Colors`` after import continue to work.
+    """
     actions = {rg.get("action") for rg in folder.get("rule_groups") or []}
     if len(actions) > 1:
-        label, icon, color = "Mixed", "⚠️ ", Colors.WARNING
-    else:
-        action_val = next(iter(actions)) if actions else folder.get("action")
-        if action_val not in (0, 1):
-            action_val = folder.get("action")
+        # "⚠️ " intentionally ends with a space; the caller format adds one
+        # more, producing the two spaces before "Mixed" asserted in tests.
+        return "Mixed", "⚠️ ", "WARNING"
 
-        prop_map: dict[int | None | str, tuple[str, str, str]] = {
-            0: ("Block", "⛔", Colors.FAIL),
-            1: ("Allow", "✅", Colors.GREEN),
-        }
-        label, icon, color = prop_map.get(
-            action_val, ("Block (Default)", "⛔", Colors.FAIL)
-        )
+    action_val = next(iter(actions)) if actions else folder.get("action")
+    if action_val not in (0, 1):
+        action_val = folder.get("action")
+
+    if action_val == 0:
+        return "Block", "⛔", "FAIL"
+    if action_val == 1:
+        return "Allow", "✅", "GREEN"
+    return "Block (Default)", "⛔", "FAIL"
+
+
+def _get_action_text(folder: PlanFolderEntry) -> str:
+    """Determine the rendered action label (Block/Allow/Mixed) for a folder."""
+    label, icon, color_attr = _resolve_folder_action(folder)
+    if USE_COLORS:
+        return f"({getattr(Colors, color_attr)}{icon} {label}{Colors.ENDC})"
+    return f"({icon} {label})"
+
+
+def _format_plan_header(profile: str) -> str:
+    """Return the header line for a plan details block."""
+    if USE_COLORS:
+        return f"\n{Colors.HEADER}📝 Plan Details for {profile}:{Colors.ENDC}"
+    return f"\n📝 Plan Details for {profile}:"
+
+
+def _format_empty_warning() -> str:
+    """Return the warning shown when a plan has no folders."""
+    if USE_COLORS:
+        return f"  {Colors.WARNING}⚠️  No folders to sync.{Colors.ENDC}"
+    return "  ⚠️  No folders to sync."
+
+
+def _format_dimmed_hint(hint: str) -> str:
+    """Return a hint string, dimmed when colors are enabled."""
+    if USE_COLORS:
+        return f"{Colors.DIM}{hint}{Colors.ENDC}"
+    return hint
+
+
+def _format_folder_line(
+    folder: PlanFolderEntry, max_name_len: int, max_rules_len: int
+) -> str:
+    """Return a single formatted folder line for the plan details table."""
+    name = sanitize_for_log(folder.get("name", "Unknown"))
+    rules_count = folder.get("rules", 0)
+    formatted_rules = f"{rules_count:,}"
+    padded_name = _pad_string(name, max_name_len, "<")
+    action_text = _get_action_text(folder)
 
     if USE_COLORS:
-        return f"({color}{icon} {label}{Colors.ENDC})"
-    return f"({icon} {label})"
+        return (
+            f"  • {Colors.BOLD}{padded_name}{Colors.ENDC} : "
+            f"{formatted_rules:>{max_rules_len}} {pluralize(rules_count, 'rule'):<5} {action_text}"
+        )
+    return (
+        f"  - {padded_name} : "
+        f"{formatted_rules:>{max_rules_len}} {pluralize(rules_count, 'rule'):<5} {action_text}"
+    )
 
 
 def print_plan_details(plan_entry: PlanEntry) -> None:
@@ -285,18 +336,14 @@ def print_plan_details(plan_entry: PlanEntry) -> None:
         profile = "(Unspecified)"
     folders = plan_entry.get("folders", [])
 
-    if USE_COLORS:
-        print(f"\n{Colors.HEADER}📝 Plan Details for {profile}:{Colors.ENDC}")
-    else:
-        print(f"\n📝 Plan Details for {profile}:")
+    print(_format_plan_header(profile))
 
     if not folders:
-        if USE_COLORS:
-            print(f"  {Colors.WARNING}⚠️  No folders to sync.{Colors.ENDC}")
-        else:
-            print("  ⚠️  No folders to sync.")
-        _print_hint(
-            "  💡 Hint: Add folder URLs using --folder-url or in your config.yaml"
+        print(_format_empty_warning())
+        print(
+            _format_dimmed_hint(
+                "  💡 Hint: Add folder URLs using --folder-url or in your config.yaml"
+            )
         )
         return
 
@@ -309,21 +356,7 @@ def print_plan_details(plan_entry: PlanEntry) -> None:
     max_rules_len = max((len(f"{f.get('rules', 0):,}") for f in folders), default=0)
 
     for folder in sorted(folders, key=lambda f: f.get("name", "Unknown")):
-        name = sanitize_for_log(folder.get("name", "Unknown"))
-        rules_count = folder.get("rules", 0)
-        formatted_rules = f"{rules_count:,}"
-
-        action_text = _get_action_text(folder)
-        padded_name = _pad_string(name, max_name_len, "<")
-
-        if USE_COLORS:
-            print(
-                f"  • {Colors.BOLD}{padded_name}{Colors.ENDC} : {formatted_rules:>{max_rules_len}} {pluralize(rules_count, 'rule'):<5} {action_text}"
-            )
-        else:
-            print(
-                f"  - {padded_name} : {formatted_rules:>{max_rules_len}} {pluralize(rules_count, 'rule'):<5} {action_text}"
-            )
+        print(_format_folder_line(folder, max_name_len, max_rules_len))
 
     print("")
 

--- a/tests/test_plan_details.py
+++ b/tests/test_plan_details.py
@@ -4,9 +4,33 @@ import importlib
 import os
 from unittest.mock import patch
 
+import pytest
+
 # NOTE: Avoid importing `main` at module import time.
 # Some tests delete `sys.modules["main"]` to force a clean import under different env/TTY
 # settings; holding a stale module reference can cause patches to target the wrong module.
+
+
+def _mark_color(monkeypatch, main_module):
+    """Patch display globals to deterministic markers for color output tests."""
+    monkeypatch.setattr(main_module.display, "USE_COLORS", True)
+    for attr, value in {
+        "HEADER": "<H>",
+        "BOLD": "<B>",
+        "FAIL": "<F>",
+        "GREEN": "<G>",
+        "WARNING": "<W>",
+        "ENDC": "<E>",
+        "DIM": "<D>",
+    }.items():
+        monkeypatch.setattr(main_module.display.Colors, attr, value)
+
+
+def _mark_no_color(monkeypatch, main_module):
+    """Patch display globals to empty values for no-color output tests."""
+    monkeypatch.setattr(main_module.display, "USE_COLORS", False)
+    for attr in ("HEADER", "BOLD", "FAIL", "GREEN", "WARNING", "ENDC", "DIM"):
+        monkeypatch.setattr(main_module.display.Colors, attr, "")
 
 
 def test_print_plan_details_no_colors(capsys):
@@ -87,3 +111,258 @@ def test_print_plan_details_with_colors(capsys):
             assert "Folder A" in output
             assert "10 rules" in output
             assert "✅ Allow" in output
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        # No action / rule_groups -> "Block (Default)"
+        (
+            False,
+            {"profile": "p", "folders": [{"name": "Default", "rules": 7}]},
+            "\n📝 Plan Details for p:\n  - Default : 7 rules (⛔ Block (Default))\n\n",
+        ),
+        (
+            True,
+            {"profile": "p", "folders": [{"name": "Default", "rules": 7}]},
+            "\n<H>📝 Plan Details for p:<E>\n  • <B>Default<E> : 7 rules (<F>⛔ Block (Default)<E>)\n\n",
+        ),
+        # Single rule_groups with unrecognized action -> double fallback to default
+        (
+            False,
+            {
+                "profile": "p",
+                "folders": [
+                    {
+                        "name": "Bad",
+                        "rules": 2,
+                        "rule_groups": [{"rules": 2, "action": 5, "status": 1}],
+                    }
+                ],
+            },
+            "\n📝 Plan Details for p:\n  - Bad : 2 rules (⛔ Block (Default))\n\n",
+        ),
+        (
+            True,
+            {
+                "profile": "p",
+                "folders": [
+                    {
+                        "name": "Bad",
+                        "rules": 2,
+                        "rule_groups": [{"rules": 2, "action": 5, "status": 1}],
+                    }
+                ],
+            },
+            "\n<H>📝 Plan Details for p:<E>\n  • <B>Bad<E> : 2 rules (<F>⛔ Block (Default)<E>)\n\n",
+        ),
+        # Single rule_groups with action: None -> double fallback to default
+        (
+            False,
+            {
+                "profile": "p",
+                "folders": [
+                    {
+                        "name": "None",
+                        "rules": 2,
+                        "rule_groups": [{"rules": 2, "action": None, "status": 1}],
+                    }
+                ],
+            },
+            "\n📝 Plan Details for p:\n  - None : 2 rules (⛔ Block (Default))\n\n",
+        ),
+        (
+            True,
+            {
+                "profile": "p",
+                "folders": [
+                    {
+                        "name": "None",
+                        "rules": 2,
+                        "rule_groups": [{"rules": 2, "action": None, "status": 1}],
+                    }
+                ],
+            },
+            "\n<H>📝 Plan Details for p:<E>\n  • <B>None<E> : 2 rules (<F>⛔ Block (Default)<E>)\n\n",
+        ),
+        # {0, None} in rule_groups -> Mixed (icon has a load-bearing trailing space)
+        (
+            False,
+            {
+                "profile": "p",
+                "folders": [
+                    {
+                        "name": "Mix",
+                        "rules": 2,
+                        "rule_groups": [
+                            {"rules": 1, "action": 0, "status": 1},
+                            {"rules": 1, "action": None, "status": 1},
+                        ],
+                    }
+                ],
+            },
+            "\n📝 Plan Details for p:\n  - Mix : 2 rules (⚠️  Mixed)\n\n",
+        ),
+        (
+            True,
+            {
+                "profile": "p",
+                "folders": [
+                    {
+                        "name": "Mix",
+                        "rules": 2,
+                        "rule_groups": [
+                            {"rules": 1, "action": 0, "status": 1},
+                            {"rules": 1, "action": None, "status": 1},
+                        ],
+                    }
+                ],
+            },
+            "\n<H>📝 Plan Details for p:<E>\n  • <B>Mix<E> : 2 rules (<W>⚠️  Mixed<E>)\n\n",
+        ),
+        # Empty rule_groups with top-level action -> use top-level action
+        (
+            False,
+            {
+                "profile": "p",
+                "folders": [
+                    {"name": "Empty", "rules": 4, "action": 0, "rule_groups": []}
+                ],
+            },
+            "\n📝 Plan Details for p:\n  - Empty : 4 rules (⛔ Block)\n\n",
+        ),
+        (
+            True,
+            {
+                "profile": "p",
+                "folders": [
+                    {"name": "Empty", "rules": 4, "action": 0, "rule_groups": []}
+                ],
+            },
+            "\n<H>📝 Plan Details for p:<E>\n  • <B>Empty<E> : 4 rules (<F>⛔ Block<E>)\n\n",
+        ),
+        # Pluralization and thousands separator alignment
+        (
+            False,
+            {
+                "profile": "p",
+                "folders": [
+                    {"name": "Small", "rules": 1, "action": 0},
+                    {"name": "Large", "rules": 1234, "action": 0},
+                ],
+            },
+            "\n📝 Plan Details for p:\n  - Large : 1,234 rules (⛔ Block)\n  - Small :     1 rule  (⛔ Block)\n\n",
+        ),
+        (
+            True,
+            {
+                "profile": "p",
+                "folders": [
+                    {"name": "Small", "rules": 1, "action": 0},
+                    {"name": "Large", "rules": 1234, "action": 0},
+                ],
+            },
+            "\n<H>📝 Plan Details for p:<E>\n  • <B>Large<E> : 1,234 rules (<F>⛔ Block<E>)\n  • <B>Small<E> :     1 rule  (<F>⛔ Block<E>)\n\n",
+        ),
+        # Wide/emoji folder names exercise _display_len/_pad_string
+        (
+            False,
+            {
+                "profile": "p",
+                "folders": [
+                    {"name": "テスト", "rules": 3, "action": 0},
+                    {"name": "abc", "rules": 3, "action": 0},
+                ],
+            },
+            "\n📝 Plan Details for p:\n  - abc    : 3 rules (⛔ Block)\n  - テスト : 3 rules (⛔ Block)\n\n",
+        ),
+        (
+            True,
+            {
+                "profile": "p",
+                "folders": [
+                    {"name": "テスト", "rules": 3, "action": 0},
+                    {"name": "abc", "rules": 3, "action": 0},
+                ],
+            },
+            "\n<H>📝 Plan Details for p:<E>\n  • <B>abc   <E> : 3 rules (<F>⛔ Block<E>)\n  • <B>テスト<E> : 3 rules (<F>⛔ Block<E>)\n\n",
+        ),
+    ],
+)
+def test_print_plan_details_characterization(monkeypatch, capsys, case):
+    """Full-output characterization matrix for edge cases and both color modes."""
+    use_colors, plan_entry, expected = case
+    import main as m
+
+    if use_colors:
+        _mark_color(monkeypatch, m)
+    else:
+        _mark_no_color(monkeypatch, m)
+
+    m.print_plan_details(plan_entry)
+    assert capsys.readouterr().out == expected
+
+
+def test_resolve_folder_action_fallbacks():
+    """Direct unit coverage for the action-resolution lookup and fallbacks."""
+    import display
+
+    # No action / no rule_groups -> default
+    assert display._resolve_folder_action({"name": "x", "rules": 1}) == (
+        "Block (Default)",
+        "⛔",
+        "FAIL",
+    )
+
+    # Single top-level action
+    assert display._resolve_folder_action({"name": "x", "rules": 1, "action": 0}) == (
+        "Block",
+        "⛔",
+        "FAIL",
+    )
+    assert display._resolve_folder_action({"name": "x", "rules": 1, "action": 1}) == (
+        "Allow",
+        "✅",
+        "GREEN",
+    )
+
+    # Single rule_groups action
+    rg = {"rules": 1, "action": 0, "status": 1}
+    assert display._resolve_folder_action(
+        {"name": "x", "rules": 1, "rule_groups": [rg]}
+    ) == (
+        "Block",
+        "⛔",
+        "FAIL",
+    )
+
+    # Mixed rule_groups actions
+    assert display._resolve_folder_action(
+        {
+            "name": "x",
+            "rules": 2,
+            "rule_groups": [
+                {"rules": 1, "action": 0, "status": 1},
+                {"rules": 1, "action": 1, "status": 1},
+            ],
+        }
+    ) == ("Mixed", "⚠️ ", "WARNING")
+
+    # Unrecognized single rule_groups action falls back to top-level action
+    assert display._resolve_folder_action(
+        {
+            "name": "x",
+            "rules": 2,
+            "action": 0,
+            "rule_groups": [{"rules": 2, "action": 5, "status": 1}],
+        }
+    ) == ("Block", "⛔", "FAIL")
+
+    # Unrecognized single rule_groups action with no top-level action -> default
+    assert display._resolve_folder_action(
+        {
+            "name": "x",
+            "rules": 2,
+            "rule_groups": [{"rules": 2, "action": 5, "status": 1}],
+        }
+    ) == ("Block (Default)", "⛔", "FAIL")


### PR DESCRIPTION
## Summary

Refactors `display.py` dry-run plan rendering to separate action resolution from formatting, making `print_plan_details` a thin print loop and improving CodeScene function-level complexity.

- [ABHI-1633](https://linear.app/abhis-space/issue/ABHI-1633/repo-health-simplify-displaypy-plan-rendering-logic)
- Part of [ABHI-1629](https://linear.app/abhis-space/issue/ABHI-1629/resolve-codescene-code-health-gates-after-mainpy-extraction)

## What Changed and Why

- Split `_get_action_text` into a pure `_resolve_folder_action(...)` that returns `(label, icon, color_attr_name)` and a thin `_get_action_text` wrapper that evaluates `USE_COLORS` and `Colors` at call time.
- Extracted string-formatting helpers `_format_plan_header`, `_format_empty_warning`, `_format_dimmed_hint`, and `_format_folder_line` so `print_plan_details` only calls `print(...)`.
- No pre-rendered strings or `Colors` values are cached at module scope; patching `USE_COLORS` / `Colors` in tests still works.
- Preserved exact user-visible output, including the load-bearing two-space `(⚠️  Mixed)` rendering and `pluralize(...):<5` padding.
- Added a parametrized characterization test matrix covering: no action, unrecognized/None rule group actions, `{0, None}` Mixed, empty `rule_groups`, pluralization, thousands-separator alignment, wide/emoji names, and both `USE_COLORS` states.

## Test Plan

```bash
uv run pytest tests/test_plan_details.py -v
uv run pytest tests/ test_main.py -q
uv run ruff check .
uv run mypy main.py models.py validation.py config.py display.py gh_client.py sync.py api_client.py cache.py fix_env.py
```

All 454 tests pass (453 + 2 subtests). CI is green: ruff, mypy, pytest, Bandit, CodeQL, CodeScene.

## Complexity / CodeScene Metrics

| Function | Before (radon CC) | After (radon CC) |
|---|---|---|
| `print_plan_details` | 9 (B) | 6 (B) |
| `_get_action_text` | 7 (B) | 2 (A) |
| `_resolve_folder_action` | — | 8 (B) |
| `display.py` average | 3.56 (A) | 3.35 (A) |

`display.py` file-level CodeScene score: **7.28 → 7.64**, with improvements in **Low Cohesion**, **Complex Method**, and **Bumpy Road Ahead**. All CodeScene quality gates pass.

## Out of Scope / Known Pre-existing Issues

- The sort key uses raw `folder.get("name")` while the printed name is `sanitize_for_log`-ed; this inconsistency is preserved as-is to avoid changing ordering behavior.
- File-level `Low Cohesion` in `display.py` is not addressed here; it would require a module split and is owned by ABHI-1629.

## Security Implications

- No secrets, credentials, or `.env` files added or exposed.
- `sanitize_for_log` is still applied to profile and folder names before rendering.

## Changelog

Added a `Changed` entry under `[Unreleased]` in `CHANGELOG.md` for the display.py plan-rendering refactor.

## Checklist

- [x] New or modified code includes relevant tests
- [x] Linter passes (`ruff check .`)
- [x] Type checker passes (`mypy ...`)
- [x] Full test suite passes (`uv run pytest tests/ test_main.py`)
- [x] CodeScene quality gates pass
- [x] `CHANGELOG.md` updated
- [x] No secrets, tokens, profiles, or `.env` files are included in this PR


Link to Devin session: https://app.devin.ai/sessions/4e2ae86c77f74f76818731ee5fa4b828
Requested by: @abhimehro
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/ctrld-sync/pull/1143" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->