### PR TITLE
refactor(gh_client): split response/error handling and fix Content-Length bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - P1: SSRF - User-Controlled URLs with Outbound Requests [\#993](https://github.com/abhimehro/ctrld-sync/issues/993)
 - 🚨 P0: Critical SSRF Vulnerability in Blocklist URL Fetching [\#987](https://github.com/abhimehro/ctrld-sync/issues/987)
 
+**Fixed:**
+
+- `gh_client.py`: corrected Content-Length parsing so a malformed header (e.g. `Response too large`) falls back to streaming instead of being mistaken for a size-limit error. Refactored `_gh_get` and `_parse_and_cache_response` into focused helpers with regression coverage in `tests/test_gh_client.py`.
+
 **Closed issues:**
 
 - Daily QA & Agentic Review — 2026-08-07 [\#1137](https://github.com/abhimehro/ctrld-sync/issues/1137)

--- a/gh_client.py
+++ b/gh_client.py
@@ -49,14 +49,14 @@ def _validate_content_type(url: str, r: httpx.Response) -> None:
         )
 
 
-def _content_length_exceeds_limit(url: str, cl: str | None) -> bool:
-    """Return True iff the declared Content-Length exceeds the max response size.
+def _content_length_exceeds_limit(url: str, cl: str | None) -> int | None:
+    """Return the parsed Content-Length if it exceeds MAX_RESPONSE_SIZE.
 
-    Logs a warning and returns False when the header is malformed so the caller
-    can fall back to the streaming size check.
+    Logs a warning and returns None when the header is malformed or within the
+    limit, so the caller can fall back to the streaming size check.
     """
     if not cl:
-        return False
+        return None
     try:
         declared = int(cl)
     except ValueError:
@@ -64,15 +64,16 @@ def _content_length_exceeds_limit(url: str, cl: str | None) -> bool:
             f"Malformed Content-Length header from {sanitize_for_log(url)}: "
             f"{sanitize_for_log(cl)}. Falling back to streaming check."
         )
-        return False
-    return declared > config.MAX_RESPONSE_SIZE
+        return None
+    if declared > config.MAX_RESPONSE_SIZE:
+        return declared
+    return None
 
 
 def _read_body(url: str, r: httpx.Response) -> bytes:
     """Stream and return the response body, enforcing MAX_RESPONSE_SIZE."""
-    if _content_length_exceeds_limit(url, r.headers.get("Content-Length")):
-        cl = r.headers.get("Content-Length")
-        declared = int(cast(str, cl))
+    declared = _content_length_exceeds_limit(url, r.headers.get("Content-Length"))
+    if declared is not None:
         raise ValueError(
             f"Response too large from {sanitize_for_log(url)} "
             f"({declared / (1024 * 1024):.2f} MB)"
@@ -191,7 +192,7 @@ def _fetch_unconditional(url: str, headers: dict[str, str]) -> dict:
 
 
 def _sanitize_http_status_error(e: httpx.HTTPStatusError) -> httpx.HTTPStatusError:
-    """Re-raise an HTTPStatusError with a sanitized message."""
+    """Construct an HTTPStatusError whose message has been sanitized."""
     return httpx.HTTPStatusError(
         sanitize_for_log(str(e)),
         request=e.request,

--- a/gh_client.py
+++ b/gh_client.py
@@ -40,69 +40,163 @@ _cache: dict[str, dict] = {}
 _cache_lock = threading.RLock()
 
 
-def _parse_and_cache_response(url: str, r: httpx.Response) -> dict:
-    """Validate, stream, parse, and cache a blocklist response."""
+def _validate_content_type(url: str, r: httpx.Response) -> None:
+    """Validate that the response Content-Type is acceptable for JSON bodies."""
+    ct = r.headers.get("Content-Type", "").lower()
+    if not any(t in ct for t in ("application/json", "text/json", "text/plain")):
+        raise ValueError(
+            f"Invalid Content-Type from {sanitize_for_log(url)}: {sanitize_for_log(ct)}."
+        )
 
-    def _validate_ct() -> None:
-        ct = r.headers.get("Content-Type", "").lower()
-        if not any(t in ct for t in ("application/json", "text/json", "text/plain")):
-            raise ValueError(
-                f"Invalid Content-Type from {sanitize_for_log(url)}: {sanitize_for_log(ct)}."
-            )
 
-    def _read_body() -> bytes:
-        cl = r.headers.get("Content-Length")
-        if cl:
-            try:
-                if int(cl) > config.MAX_RESPONSE_SIZE:
-                    raise ValueError(
-                        f"Response too large from {sanitize_for_log(url)} "
-                        f"({int(cl) / (1024 * 1024):.2f} MB)"
-                    )
-            except ValueError as e:
-                if "Response too large" in str(e):
-                    raise
-                log.warning(
-                    f"Malformed Content-Length header from {sanitize_for_log(url)}: "
-                    f"{sanitize_for_log(cl)}. Falling back to streaming check."
-                )
-        chunks = []
-        current_size = 0
-        for chunk in r.iter_bytes(chunk_size=16 * 1024):
-            current_size += len(chunk)
-            if current_size > config.MAX_RESPONSE_SIZE:
-                raise ValueError(
-                    f"Response too large from {sanitize_for_log(url)} "
-                    f"(> {config.MAX_RESPONSE_SIZE / (1024 * 1024):.2f} MB)"
-                )
-            chunks.append(chunk)
-        return b"".join(chunks)
+def _content_length_exceeds_limit(url: str, cl: str | None) -> bool:
+    """Return True iff the declared Content-Length exceeds the max response size.
 
-    _validate_ct()
-    body_bytes = _read_body()
-
+    Logs a warning and returns False when the header is malformed so the caller
+    can fall back to the streaming size check.
+    """
+    if not cl:
+        return False
     try:
-        data = json.loads(body_bytes)
+        declared = int(cl)
+    except ValueError:
+        log.warning(
+            f"Malformed Content-Length header from {sanitize_for_log(url)}: "
+            f"{sanitize_for_log(cl)}. Falling back to streaming check."
+        )
+        return False
+    return declared > config.MAX_RESPONSE_SIZE
+
+
+def _read_body(url: str, r: httpx.Response) -> bytes:
+    """Stream and return the response body, enforcing MAX_RESPONSE_SIZE."""
+    if _content_length_exceeds_limit(url, r.headers.get("Content-Length")):
+        cl = r.headers.get("Content-Length")
+        declared = int(cast(str, cl))
+        raise ValueError(
+            f"Response too large from {sanitize_for_log(url)} "
+            f"({declared / (1024 * 1024):.2f} MB)"
+        )
+
+    chunks: list[bytes] = []
+    current_size = 0
+    for chunk in r.iter_bytes(chunk_size=16 * 1024):
+        current_size += len(chunk)
+        if current_size > config.MAX_RESPONSE_SIZE:
+            raise ValueError(
+                f"Response too large from {sanitize_for_log(url)} "
+                f"(> {config.MAX_RESPONSE_SIZE / (1024 * 1024):.2f} MB)"
+            )
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def _parse_json_bytes(url: str, body_bytes: bytes) -> Any:
+    """Parse a JSON body, re-raising JSONDecodeError as a sanitized ValueError."""
+    try:
+        return json.loads(body_bytes)
     except json.JSONDecodeError:
         raise ValueError(
             f"Invalid JSON response from {sanitize_for_log(url)}"
         ) from None
 
-    # Store cache headers for future conditional requests
-    etag = r.headers.get("ETag")
-    last_modified = r.headers.get("Last-Modified")
 
-    # Update disk cache with new data and headers
-    _disk_cache[url] = {
+def _build_cache_entry(data: Any, r: httpx.Response) -> dict[str, Any]:
+    """Build a disk-cache entry from parsed data and response headers."""
+    return {
         "data": data,
-        "etag": etag,
-        "last_modified": last_modified,
+        "etag": r.headers.get("ETag"),
+        "last_modified": r.headers.get("Last-Modified"),
         "fetched_at": time.time(),
         "last_validated": time.time(),
     }
 
+
+def _record_cache_miss() -> None:
+    """Increment the cache-miss counter."""
     _cache_stats["misses"] += 1
+
+
+def _parse_and_cache_response(url: str, r: httpx.Response) -> dict:
+    """Validate, stream, parse, and cache a blocklist response."""
+    _validate_content_type(url, r)
+    body_bytes = _read_body(url, r)
+    data = _parse_json_bytes(url, body_bytes)
+
+    # Update disk cache with new data and headers
+    _disk_cache[url] = _build_cache_entry(data, r)
+
+    _record_cache_miss()
     return cast(dict, data)
+
+
+def _get_memory_cached(url: str) -> dict | None:
+    """Return the in-memory cached entry if present, incrementing hits."""
+    with _cache_lock:
+        if (cached := _cache.get(url)) is not None:
+            _cache_stats["hits"] += 1
+            return cached
+    return None
+
+
+def _count_blocklist_fetch() -> None:
+    """Increment the blocklist fetch counter before issuing a request."""
+    with _cache_lock:
+        _api_stats["blocklist_fetches"] += 1
+
+
+def _serve_disk_ttl_hit(url: str, cached_entry: dict[str, Any]) -> dict:
+    """Return a disk-cached entry that is still within TTL, promoting it to memory."""
+    data = cached_entry["data"]
+    with _cache_lock:
+        _cache[url] = data
+    _cache_stats["hits"] += 1
+    if log.isEnabledFor(logging.DEBUG):
+        log.debug(f"Disk cache hit (within TTL) for {sanitize_for_log(url)}")
+    return cast(dict, data)
+
+
+def _build_conditional_headers(cached_entry: dict[str, Any]) -> dict[str, str]:
+    """Build If-None-Match / If-Modified-Since headers from a disk-cache entry."""
+    headers: dict[str, str] = {}
+    etag = cached_entry.get("etag")
+    if etag:
+        headers["If-None-Match"] = etag
+    last_modified = cached_entry.get("last_modified")
+    if last_modified:
+        headers["If-Modified-Since"] = last_modified
+    return headers
+
+
+def _handle_304_with_data(url: str, cached_entry: dict[str, Any]) -> dict:
+    """Handle a 304 Not Modified response when cached data is available."""
+    if log.isEnabledFor(logging.DEBUG):
+        log.debug(f"Cache validated (304) for {sanitize_for_log(url)}")
+    _cache_stats["validations"] += 1
+
+    data = cached_entry["data"]
+    with _cache_lock:
+        _cache[url] = data
+
+    # Update timestamp in disk cache to track last validation
+    cached_entry["last_validated"] = time.time()
+    return cast(dict, data)
+
+
+def _fetch_unconditional(url: str, headers: dict[str, str]) -> dict:
+    """Issue a fresh GET request and parse/store its response."""
+    with _gh.stream("GET", url, headers=headers) as r:
+        r.raise_for_status()
+        return _parse_and_cache_response(url, r)
+
+
+def _sanitize_http_status_error(e: httpx.HTTPStatusError) -> httpx.HTTPStatusError:
+    """Re-raise an HTTPStatusError with a sanitized message."""
+    return httpx.HTTPStatusError(
+        sanitize_for_log(str(e)),
+        request=e.request,
+        response=e.response,
+    )
 
 
 def _gh_get(url: str) -> dict:
@@ -118,38 +212,24 @@ def _gh_get(url: str) -> dict:
     SECURITY: Validates data structure regardless of cache source
     """
     # First check: Quick check without holding lock for long
-    with _cache_lock:
-        if (cached := _cache.get(url)) is not None:
-            _cache_stats["hits"] += 1
-            return cached
+    if (cached := _get_memory_cached(url)) is not None:
+        return cached
 
     # Track that we're about to make a blocklist fetch
-    with _cache_lock:
-        _api_stats["blocklist_fetches"] += 1
+    _count_blocklist_fetch()
 
     # Check disk cache for TTL-based hit or conditional request headers
-    headers = {}
+    headers: dict[str, str] = {}
     cached_entry = _disk_cache.get(url)
     if cached_entry:
         last_validated = cached_entry.get("last_validated", 0)
         if time.time() - last_validated < CACHE_TTL_SECONDS:
             # Within TTL: return cached data directly without any HTTP request
-            data = cached_entry["data"]
-            with _cache_lock:
-                _cache[url] = data
-            _cache_stats["hits"] += 1
-            if log.isEnabledFor(logging.DEBUG):
-                log.debug(f"Disk cache hit (within TTL) for {sanitize_for_log(url)}")
-            return cast(dict, data)
+            return _serve_disk_ttl_hit(url, cached_entry)
         # Beyond TTL: send conditional request using cached ETag/Last-Modified
         # Server returns 304 if content hasn't changed
         # NOTE: Cached values may be None if the server didn't send these headers.
-        etag = cached_entry.get("etag")
-        if etag:
-            headers["If-None-Match"] = etag
-        last_modified = cached_entry.get("last_modified")
-        if last_modified:
-            headers["If-Modified-Since"] = last_modified
+        headers = _build_conditional_headers(cached_entry)
 
     # Fetch data (or validate cache)
     # Explicitly let HTTPError propagate (no need to catch just to re-raise)
@@ -158,18 +238,8 @@ def _gh_get(url: str) -> dict:
             # Handle 304 Not Modified - cached data is still valid
             if r.status_code == 304:
                 if cached_entry and "data" in cached_entry:
-                    if log.isEnabledFor(logging.DEBUG):
-                        log.debug(f"Cache validated (304) for {sanitize_for_log(url)}")
-                    _cache_stats["validations"] += 1
+                    return _handle_304_with_data(url, cached_entry)
 
-                    # Update in-memory cache with validated data
-                    data = cached_entry["data"]
-                    with _cache_lock:
-                        _cache[url] = data
-
-                    # Update timestamp in disk cache to track last validation
-                    cached_entry["last_validated"] = time.time()
-                    return cast(dict, data)
                 # Shouldn't happen, but handle gracefully
                 log.warning(
                     f"Got 304 but no cached data for {sanitize_for_log(url)}, re-fetching"
@@ -179,21 +249,13 @@ def _gh_get(url: str) -> dict:
                 r.close()
                 # Retry without conditional headers using streaming again so that
                 # MAX_RESPONSE_SIZE and related protections still apply.
-                headers = {}
-                with _gh.stream("GET", url, headers=headers) as r_retry:
-                    r_retry.raise_for_status()
-                    return _parse_and_cache_response(url, r_retry)
+                return _fetch_unconditional(url, {})
 
             r.raise_for_status()
             data = _parse_and_cache_response(url, r)
-
     except httpx.HTTPStatusError as e:
         # Re-raise with sanitized exception to prevent data leakage
-        raise httpx.HTTPStatusError(
-            sanitize_for_log(str(e)),
-            request=e.request,
-            response=e.response,
-        ) from None
+        raise _sanitize_http_status_error(e) from None
 
     # Double-checked locking: Check again after fetch to avoid duplicate fetches
     # If another thread already cached it while we were fetching, use theirs

--- a/gh_client.py
+++ b/gh_client.py
@@ -49,7 +49,7 @@ def _validate_content_type(url: str, r: httpx.Response) -> None:
         )
 
 
-def _content_length_exceeds_limit(url: str, cl: str | None) -> int | None:
+def _content_length_if_over_limit(url: str, cl: str | None) -> int | None:
     """Return the parsed Content-Length if it exceeds MAX_RESPONSE_SIZE.
 
     Logs a warning and returns None when the header is malformed or within the
@@ -72,7 +72,7 @@ def _content_length_exceeds_limit(url: str, cl: str | None) -> int | None:
 
 def _read_body(url: str, r: httpx.Response) -> bytes:
     """Stream and return the response body, enforcing MAX_RESPONSE_SIZE."""
-    declared = _content_length_exceeds_limit(url, r.headers.get("Content-Length"))
+    declared = _content_length_if_over_limit(url, r.headers.get("Content-Length"))
     if declared is not None:
         raise ValueError(
             f"Response too large from {sanitize_for_log(url)} "

--- a/main.py
+++ b/main.py
@@ -530,7 +530,10 @@ def parse_args() -> argparse.Namespace:
         "--profiles", help="Comma-separated list of profile IDs", default=None
     )
     parser.add_argument(
-        "--folder-url", action="append", help="Folder JSON URL (repeatable)", default=None
+        "--folder-url",
+        action="append",
+        help="Folder JSON URL (repeatable)",
+        default=None,
     )
     parser.add_argument("--dry-run", action="store_true", help="Plan only")
     parser.add_argument(

--- a/tests/test_gh_client.py
+++ b/tests/test_gh_client.py
@@ -1,0 +1,487 @@
+"""Characterization and regression tests for gh_client.py."""
+
+import json
+import logging
+import os
+import sys
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import api_client
+import cache
+import config
+import gh_client
+import validation
+
+
+def _make_json_body(data: dict) -> bytes:
+    return json.dumps(data).encode()
+
+
+def _make_stream_response(
+    status_code: int = 200,
+    body: bytes | None = None,
+    headers: dict[str, str] | None = None,
+    raise_for_status: Exception | None = None,
+) -> MagicMock:
+    """Build a MagicMock that behaves like an httpx streaming response context."""
+    response = MagicMock()
+    response.status_code = status_code
+    response.headers = {"Content-Type": "application/json"} | (headers or {})
+    if body is not None:
+        response.iter_bytes = MagicMock(return_value=[body])
+    else:
+        response.iter_bytes = MagicMock(return_value=[])
+    response.raise_for_status = MagicMock()
+    if raise_for_status is not None:
+        response.raise_for_status.side_effect = raise_for_status
+    response.__enter__ = MagicMock(return_value=response)
+    response.__exit__ = MagicMock(return_value=None)
+    response.close = MagicMock()
+    return response
+
+
+def _make_http_status_error(
+    status_code: int, message: str | None = None
+) -> httpx.HTTPStatusError:
+    request = MagicMock(spec=httpx.Request)
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = status_code
+    response.request = request
+    return httpx.HTTPStatusError(
+        message or f"{status_code} Error",
+        request=request,
+        response=response,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_client_state():
+    """Snapshot live stats/dicts so tests can assert on deltas, not absolutes."""
+    stats_before = dict(cache._cache_stats)
+    api_before = dict(api_client._api_stats)
+    token_before = validation._token
+    gh_client._cache.clear()
+    cache._disk_cache.clear()
+    validation.validate_folder_url.cache_clear()
+    validation.validate_hostname.cache_clear()
+    yield
+    gh_client._cache.clear()
+    cache._disk_cache.clear()
+    validation.validate_folder_url.cache_clear()
+    validation.validate_hostname.cache_clear()
+    cache._cache_stats.clear()
+    cache._cache_stats.update(stats_before)
+    api_client._api_stats.clear()
+    api_client._api_stats.update(api_before)
+    validation.set_token_for_redaction(token_before)
+
+
+class TestParseAndCacheResponse:
+    """Regression tests for _parse_and_cache_response and its helpers."""
+
+    def test_parses_valid_json_and_caches(self):
+        url = "https://example.com/valid.json"
+        data = {"group": {"group": "Test"}}
+        body = _make_json_body(data)
+        response = _make_stream_response(body=body)
+
+        misses_before = cache._cache_stats["misses"]
+        result = gh_client._parse_and_cache_response(url, response)
+
+        assert result == data
+        assert cache._cache_stats["misses"] == misses_before + 1
+        assert cache._disk_cache[url]["data"] == data
+        assert "etag" in cache._disk_cache[url]
+        assert "fetched_at" in cache._disk_cache[url]
+        assert "last_validated" in cache._disk_cache[url]
+
+    @pytest.mark.parametrize(
+        "content_type",
+        [
+            "application/json",
+            "text/plain; charset=utf-8",
+            "text/json",
+            "application/json; charset=utf-8",
+        ],
+    )
+    def test_accepts_allowed_content_types(self, content_type):
+        url = "https://example.com/ct.json"
+        data = {"group": {"group": "Test"}}
+        response = _make_stream_response(
+            body=_make_json_body(data), headers={"Content-Type": content_type}
+        )
+
+        result = gh_client._parse_and_cache_response(url, response)
+        assert result == data
+
+    @pytest.mark.parametrize(
+        "content_type",
+        ["text/html", "application/xml"],
+    )
+    def test_rejects_disallowed_content_types(self, content_type):
+        url = "https://example.com/ct.json"
+        response = _make_stream_response(
+            body=b'{"group": {"group": "Test"}}',
+            headers={"Content-Type": content_type},
+        )
+
+        with pytest.raises(ValueError, match="Invalid Content-Type"):
+            gh_client._parse_and_cache_response(url, response)
+
+    def test_content_length_too_large_string_does_not_spuriously_raise(self, caplog):
+        """Regression for the crafted-Content-Length bug (ABHI-1634 §2a)."""
+        url = "https://example.com/crafted.json"
+        data = {"group": {"group": "Test"}}
+        response = _make_stream_response(
+            body=_make_json_body(data),
+            headers={"Content-Length": "Response too large"},
+        )
+
+        with caplog.at_level(logging.WARNING):
+            result = gh_client._parse_and_cache_response(url, response)
+
+        assert result == data
+        assert "Malformed Content-Length header" in caplog.text
+        response.iter_bytes.assert_called_once()
+
+    def test_malformed_content_length_falls_back_to_streaming(self, caplog):
+        url = "https://example.com/malformed.json"
+        data = {"group": {"group": "Test"}}
+        response = _make_stream_response(
+            body=_make_json_body(data),
+            headers={"Content-Length": "abc"},
+        )
+
+        with caplog.at_level(logging.WARNING):
+            result = gh_client._parse_and_cache_response(url, response)
+
+        assert result == data
+        assert "Malformed Content-Length header" in caplog.text
+
+    def test_content_length_over_max_raises_before_reading_body(self):
+        url = "https://example.com/huge.json"
+        response = _make_stream_response(
+            body=b'{"group": {"group": "Test"}}',
+            headers={"Content-Length": str(config.MAX_RESPONSE_SIZE + 1)},
+        )
+
+        with pytest.raises(ValueError, match="Response too large"):
+            gh_client._parse_and_cache_response(url, response)
+
+        response.iter_bytes.assert_not_called()
+
+    def test_streaming_body_over_max_raises_during_iteration(self):
+        url = "https://example.com/huge.json"
+        response = _make_stream_response(
+            body=None,
+            headers={"Content-Length": str(config.MAX_RESPONSE_SIZE - 1)},
+        )
+        response.iter_bytes = MagicMock(
+            return_value=[b"x" * (config.MAX_RESPONSE_SIZE + 1)]
+        )
+
+        with pytest.raises(ValueError, match="Response too large"):
+            gh_client._parse_and_cache_response(url, response)
+
+        response.iter_bytes.assert_called_once()
+
+    def test_invalid_json_does_not_write_disk_cache_entry(self):
+        url = "https://example.com/bad.json"
+        response = _make_stream_response(body=b"not json")
+
+        with pytest.raises(ValueError, match="Invalid JSON response"):
+            gh_client._parse_and_cache_response(url, response)
+
+        assert url not in cache._disk_cache
+
+
+class TestGhGet:
+    """Regression tests for _gh_get cache and HTTP handling."""
+
+    def test_in_memory_hit_returns_cached_object(self):
+        url = "https://example.com/cached.json"
+        data = {"group": {"group": "Test"}}
+        gh_client._cache[url] = data
+
+        hits_before = cache._cache_stats["hits"]
+        with patch.object(gh_client._gh, "stream") as mock_stream:
+            result = gh_client._gh_get(url)
+
+        assert result is data
+        assert cache._cache_stats["hits"] == hits_before + 1
+        mock_stream.assert_not_called()
+
+    def test_disk_ttl_hit_returns_without_http_and_counts_fetch(self):
+        url = "https://example.com/ttl.json"
+        data = {"group": {"group": "Test"}}
+        cache._disk_cache[url] = {
+            "data": data,
+            "etag": None,
+            "last_modified": None,
+            "fetched_at": time.time(),
+            "last_validated": time.time(),
+        }
+
+        hits_before = cache._cache_stats["hits"]
+        fetches_before = api_client._api_stats["blocklist_fetches"]
+
+        with patch.object(gh_client._gh, "stream") as mock_stream:
+            result = gh_client._gh_get(url)
+
+        assert result == data
+        assert result is data
+        assert cache._cache_stats["hits"] == hits_before + 1
+        assert api_client._api_stats["blocklist_fetches"] == fetches_before + 1
+        assert gh_client._cache[url] is data
+        mock_stream.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("etag", "last_modified", "expected_headers"),
+        [
+            ("abc123", None, {"If-None-Match": "abc123"}),
+            (
+                None,
+                "Mon, 01 Jan 2024 00:00:00 GMT",
+                {"If-Modified-Since": "Mon, 01 Jan 2024 00:00:00 GMT"},
+            ),
+            (
+                "abc123",
+                "Mon, 01 Jan 2024 00:00:00 GMT",
+                {
+                    "If-None-Match": "abc123",
+                    "If-Modified-Since": "Mon, 01 Jan 2024 00:00:00 GMT",
+                },
+            ),
+            (None, None, {}),
+        ],
+    )
+    def test_conditional_headers_from_disk_cache(
+        self, etag, last_modified, expected_headers
+    ):
+        url = "https://example.com/cond.json"
+        data = {"group": {"group": "Test"}}
+        cache._disk_cache[url] = {
+            "data": data,
+            "etag": etag,
+            "last_modified": last_modified,
+            "fetched_at": 0.0,
+            "last_validated": 0.0,
+        }
+
+        captured = {}
+
+        def mock_stream(method, stream_url, headers=None):
+            captured["headers"] = headers
+            return _make_stream_response(status_code=304, headers={})
+
+        with patch.object(gh_client._gh, "stream", side_effect=mock_stream):
+            result = gh_client._gh_get(url)
+
+        assert result == data
+        assert captured["headers"] == expected_headers
+
+    def test_304_with_cached_data_validates_and_updates_timestamp(self):
+        url = "https://example.com/304.json"
+        data = {"group": {"group": "Test"}}
+        cache._disk_cache[url] = {
+            "data": data,
+            "etag": "abc123",
+            "last_modified": None,
+            "fetched_at": 0.0,
+            "last_validated": 0.0,
+        }
+
+        validations_before = cache._cache_stats["validations"]
+        response = _make_stream_response(status_code=304)
+
+        with patch.object(gh_client._gh, "stream", return_value=response):
+            result = gh_client._gh_get(url)
+
+        assert result is data
+        assert cache._cache_stats["validations"] == validations_before + 1
+        assert gh_client._cache[url] is data
+        assert cache._disk_cache[url]["last_validated"] > 0.0
+
+    def test_304_without_cached_data_retries_unconditionally(self, caplog):
+        url = "https://example.com/304-retry.json"
+        cache._disk_cache[url] = {
+            "etag": "abc123",
+            "last_modified": None,
+            "fetched_at": 0.0,
+            "last_validated": 0.0,
+        }
+        data = {"group": {"group": "Test"}}
+
+        resp_304 = _make_stream_response(status_code=304, headers={})
+        resp_200 = _make_stream_response(status_code=200, body=_make_json_body(data))
+
+        errors_before = cache._cache_stats["errors"]
+
+        call_count = []
+
+        def mock_stream(method, stream_url, headers=None):
+            if not call_count:
+                call_count.append(1)
+                assert headers.get("If-None-Match") == "abc123"
+                return resp_304
+            call_count.append(2)
+            assert headers == {}
+            return resp_200
+
+        with caplog.at_level(logging.WARNING):
+            with patch.object(
+                gh_client._gh, "stream", side_effect=mock_stream
+            ) as patched_stream:
+                result = gh_client._gh_get(url)
+
+        assert result == data
+        assert cache._cache_stats["errors"] == errors_before + 1
+        assert "Got 304 but no cached data" in caplog.text
+        assert patched_stream.call_count == 2
+
+    def test_http_status_error_is_sanitized_and_suppresses_cause(self, monkeypatch):
+        url = "https://example.com/secret.json?token=TOPSECRET"
+        err = _make_http_status_error(404, "404 Not Found: token=TOPSECRET")
+        response = _make_stream_response(raise_for_status=err)
+
+        monkeypatch.setattr(validation, "_token", "TOPSECRET")
+
+        with patch.object(gh_client._gh, "stream", return_value=response):
+            with pytest.raises(httpx.HTTPStatusError) as exc_info:
+                gh_client._gh_get(url)
+
+        assert "TOPSECRET" not in str(exc_info.value)
+        assert "[REDACTED]" in str(exc_info.value)
+        assert exc_info.value.__cause__ is None
+
+    def test_double_checked_locking_returns_first_callers_object(self):
+        url = "https://example.com/race.json"
+        data = {"group": {"group": "Test"}}
+        barrier = threading.Barrier(2, timeout=10)
+
+        def make_response(*args, **kwargs):
+            return _make_stream_response(body=_make_json_body(data))
+
+        def wrapped_parse(stream_url, r):
+            # Parse without touching the disk cache so the second thread cannot
+            # take a disk TTL shortcut before the double-checked lock.
+            body = b"".join(r.iter_bytes())
+            result = json.loads(body)
+            barrier.wait()
+            return result
+
+        results = []
+        errors = []
+
+        def fetch():
+            try:
+                results.append(gh_client._gh_get(url))
+            except Exception as e:  # pragma: no cover
+                errors.append(e)
+
+        with patch.object(gh_client._gh, "stream", side_effect=make_response):
+            with patch.object(
+                gh_client, "_parse_and_cache_response", side_effect=wrapped_parse
+            ):
+                threads = [threading.Thread(target=fetch) for _ in range(2)]
+                for t in threads:
+                    t.start()
+                for t in threads:
+                    t.join()
+
+        assert not errors
+        assert len(results) == 2
+        assert results[0] is results[1]
+
+
+class TestFetchFolderData:
+    """Regression tests for fetch_folder_data error/hint handling."""
+
+    def test_returns_data_when_valid(self):
+        url = "https://example.com/folder.json"
+        data = {"group": {"group": "Test"}, "rules": [{"PK": "example.com"}]}
+
+        with patch.object(gh_client, "_gh_get", return_value=data):
+            result = gh_client.fetch_folder_data(url)
+
+        assert result is data
+
+    def test_http_error_includes_status_hint_and_sanitized_url(self):
+        url = "https://example.com/folder.json?token=SECRET"
+        err = _make_http_status_error(401, "401 Unauthorized")
+
+        with patch.object(gh_client, "_gh_get", side_effect=err):
+            with pytest.raises(httpx.HTTPStatusError) as exc_info:
+                gh_client.fetch_folder_data(url)
+
+        msg = str(exc_info.value)
+        assert "TOKEN" in msg
+        assert "SECRET" not in msg
+        assert "example.com/folder.json" in msg
+
+    def test_validation_failure_raises_key_error(self):
+        url = "https://example.com/folder.json"
+
+        with patch.object(gh_client, "_gh_get", return_value={"bad": "data"}):
+            with patch.object(gh_client, "validate_folder_data", return_value=False):
+                with pytest.raises(KeyError, match="Invalid folder data"):
+                    gh_client.fetch_folder_data(url)
+
+
+class TestWarmUpCache:
+    """Regression tests for warm_up_cache."""
+
+    def test_swallows_per_url_exceptions_and_completes(self, monkeypatch, caplog):
+        urls = ["https://example.com/ok.json", "https://example.com/fail.json"]
+
+        def fake_gh_get(stream_url: str) -> dict:
+            if "fail" in stream_url:
+                raise ValueError("boom")
+            return {"group": {"group": "Test"}}
+
+        monkeypatch.setattr(gh_client, "validate_folder_url", lambda url: True)
+        monkeypatch.setattr(gh_client, "_gh_get", fake_gh_get)
+        completion = MagicMock()
+        monkeypatch.setattr(gh_client, "_print_completion", completion)
+        monkeypatch.setattr(gh_client, "_clear_current_line", MagicMock())
+        monkeypatch.setattr(gh_client, "render_progress_bar", MagicMock())
+        monkeypatch.setattr(gh_client, "USE_COLORS", True)
+
+        with caplog.at_level(logging.WARNING):
+            gh_client.warm_up_cache(urls)
+
+        completion.assert_called_once_with("Warming up cache: Done!")
+        assert any("Failed to pre-fetch" in r.message for r in caplog.records)
+
+    def test_skips_urls_already_in_memory_cache(self, monkeypatch):
+        url = "https://example.com/already.json"
+        data = {"group": {"group": "Test"}}
+        gh_client._cache[url] = data
+
+        fake_gh_get = MagicMock()
+        monkeypatch.setattr(gh_client, "_gh_get", fake_gh_get)
+
+        gh_client.warm_up_cache([url])
+
+        fake_gh_get.assert_not_called()
+
+
+class TestValidateAndFetchUrl:
+    """Regression tests for _validate_and_fetch_url."""
+
+    def test_returns_none_for_invalid_url(self, monkeypatch):
+        url = "https://notallowed.example/data.json"
+        fake_gh_get = MagicMock()
+        monkeypatch.setattr(gh_client, "_gh_get", fake_gh_get)
+
+        result = gh_client._validate_and_fetch_url(url)
+
+        assert result is None
+        fake_gh_get.assert_not_called()

--- a/tests/test_gh_client.py
+++ b/tests/test_gh_client.py
@@ -33,9 +33,14 @@ def _make_stream_response(
     """Build a MagicMock that behaves like an httpx streaming response context."""
     response = MagicMock()
     response.status_code = status_code
-    response.headers = {"Content-Type": "application/json"} | (headers or {})
+    merged_headers = {"Content-Type": "application/json"} | (headers or {})
+    response.headers = httpx.Headers(merged_headers)
     if body is not None:
-        response.iter_bytes = MagicMock(return_value=[body])
+        response.iter_bytes = MagicMock(
+            side_effect=lambda chunk_size=16 * 1024: (
+                body[i : i + chunk_size] for i in range(0, len(body), chunk_size)
+            )
+        )
     else:
         response.iter_bytes = MagicMock(return_value=[])
     response.raise_for_status = MagicMock()
@@ -95,12 +100,12 @@ class TestParseAndCacheResponse:
         misses_before = cache._cache_stats["misses"]
         result = gh_client._parse_and_cache_response(url, response)
 
-        assert result == data
-        assert cache._cache_stats["misses"] == misses_before + 1
-        assert cache._disk_cache[url]["data"] == data
-        assert "etag" in cache._disk_cache[url]
-        assert "fetched_at" in cache._disk_cache[url]
-        assert "last_validated" in cache._disk_cache[url]
+        assert result == data  # nosec B101
+        assert cache._cache_stats["misses"] == misses_before + 1  # nosec B101
+        assert cache._disk_cache[url]["data"] == data  # nosec B101
+        assert "etag" in cache._disk_cache[url]  # nosec B101
+        assert "fetched_at" in cache._disk_cache[url]  # nosec B101
+        assert "last_validated" in cache._disk_cache[url]  # nosec B101
 
     @pytest.mark.parametrize(
         "content_type",
@@ -119,7 +124,7 @@ class TestParseAndCacheResponse:
         )
 
         result = gh_client._parse_and_cache_response(url, response)
-        assert result == data
+        assert result == data  # nosec B101
 
     @pytest.mark.parametrize(
         "content_type",
@@ -147,8 +152,8 @@ class TestParseAndCacheResponse:
         with caplog.at_level(logging.WARNING):
             result = gh_client._parse_and_cache_response(url, response)
 
-        assert result == data
-        assert "Malformed Content-Length header" in caplog.text
+        assert result == data  # nosec B101
+        assert "Malformed Content-Length header" in caplog.text  # nosec B101
         response.iter_bytes.assert_called_once()
 
     def test_malformed_content_length_falls_back_to_streaming(self, caplog):
@@ -162,8 +167,8 @@ class TestParseAndCacheResponse:
         with caplog.at_level(logging.WARNING):
             result = gh_client._parse_and_cache_response(url, response)
 
-        assert result == data
-        assert "Malformed Content-Length header" in caplog.text
+        assert result == data  # nosec B101
+        assert "Malformed Content-Length header" in caplog.text  # nosec B101
 
     def test_content_length_over_max_raises_before_reading_body(self):
         url = "https://example.com/huge.json"
@@ -180,11 +185,8 @@ class TestParseAndCacheResponse:
     def test_streaming_body_over_max_raises_during_iteration(self):
         url = "https://example.com/huge.json"
         response = _make_stream_response(
-            body=None,
+            body=b"x" * (config.MAX_RESPONSE_SIZE + 1),
             headers={"Content-Length": str(config.MAX_RESPONSE_SIZE - 1)},
-        )
-        response.iter_bytes = MagicMock(
-            return_value=[b"x" * (config.MAX_RESPONSE_SIZE + 1)]
         )
 
         with pytest.raises(ValueError, match="Response too large"):
@@ -199,7 +201,7 @@ class TestParseAndCacheResponse:
         with pytest.raises(ValueError, match="Invalid JSON response"):
             gh_client._parse_and_cache_response(url, response)
 
-        assert url not in cache._disk_cache
+        assert url not in cache._disk_cache  # nosec B101
 
 
 class TestGhGet:
@@ -214,8 +216,8 @@ class TestGhGet:
         with patch.object(gh_client._gh, "stream") as mock_stream:
             result = gh_client._gh_get(url)
 
-        assert result is data
-        assert cache._cache_stats["hits"] == hits_before + 1
+        assert result is data  # nosec B101
+        assert cache._cache_stats["hits"] == hits_before + 1  # nosec B101
         mock_stream.assert_not_called()
 
     def test_disk_ttl_hit_returns_without_http_and_counts_fetch(self):
@@ -235,11 +237,11 @@ class TestGhGet:
         with patch.object(gh_client._gh, "stream") as mock_stream:
             result = gh_client._gh_get(url)
 
-        assert result == data
-        assert result is data
-        assert cache._cache_stats["hits"] == hits_before + 1
-        assert api_client._api_stats["blocklist_fetches"] == fetches_before + 1
-        assert gh_client._cache[url] is data
+        assert result == data  # nosec B101
+        assert result is data  # nosec B101
+        assert cache._cache_stats["hits"] == hits_before + 1  # nosec B101
+        assert api_client._api_stats["blocklist_fetches"] == fetches_before + 1  # nosec B101
+        assert gh_client._cache[url] is data  # nosec B101
         mock_stream.assert_not_called()
 
     @pytest.mark.parametrize(
@@ -284,8 +286,8 @@ class TestGhGet:
         with patch.object(gh_client._gh, "stream", side_effect=mock_stream):
             result = gh_client._gh_get(url)
 
-        assert result == data
-        assert captured["headers"] == expected_headers
+        assert result == data  # nosec B101
+        assert captured["headers"] == expected_headers  # nosec B101
 
     def test_304_with_cached_data_validates_and_updates_timestamp(self):
         url = "https://example.com/304.json"
@@ -304,10 +306,10 @@ class TestGhGet:
         with patch.object(gh_client._gh, "stream", return_value=response):
             result = gh_client._gh_get(url)
 
-        assert result is data
-        assert cache._cache_stats["validations"] == validations_before + 1
-        assert gh_client._cache[url] is data
-        assert cache._disk_cache[url]["last_validated"] > 0.0
+        assert result is data  # nosec B101
+        assert cache._cache_stats["validations"] == validations_before + 1  # nosec B101
+        assert gh_client._cache[url] is data  # nosec B101
+        assert cache._disk_cache[url]["last_validated"] > 0.0  # nosec B101
 
     def test_304_without_cached_data_retries_unconditionally(self, caplog):
         url = "https://example.com/304-retry.json"
@@ -329,10 +331,10 @@ class TestGhGet:
         def mock_stream(method, stream_url, headers=None):
             if not call_count:
                 call_count.append(1)
-                assert headers.get("If-None-Match") == "abc123"
+                assert headers.get("If-None-Match") == "abc123"  # nosec B101
                 return resp_304
             call_count.append(2)
-            assert headers == {}
+            assert headers == {}  # nosec B101
             return resp_200
 
         with caplog.at_level(logging.WARNING):
@@ -341,10 +343,10 @@ class TestGhGet:
             ) as patched_stream:
                 result = gh_client._gh_get(url)
 
-        assert result == data
-        assert cache._cache_stats["errors"] == errors_before + 1
-        assert "Got 304 but no cached data" in caplog.text
-        assert patched_stream.call_count == 2
+        assert result == data  # nosec B101
+        assert cache._cache_stats["errors"] == errors_before + 1  # nosec B101
+        assert "Got 304 but no cached data" in caplog.text  # nosec B101
+        assert patched_stream.call_count == 2  # nosec B101
 
     def test_http_status_error_is_sanitized_and_suppresses_cause(self, monkeypatch):
         url = "https://example.com/secret.json?token=TOPSECRET"
@@ -357,9 +359,9 @@ class TestGhGet:
             with pytest.raises(httpx.HTTPStatusError) as exc_info:
                 gh_client._gh_get(url)
 
-        assert "TOPSECRET" not in str(exc_info.value)
-        assert "[REDACTED]" in str(exc_info.value)
-        assert exc_info.value.__cause__ is None
+        assert "TOPSECRET" not in str(exc_info.value)  # nosec B101
+        assert "[REDACTED]" in str(exc_info.value)  # nosec B101
+        assert exc_info.value.__cause__ is None  # nosec B101
 
     def test_double_checked_locking_returns_first_callers_object(self):
         url = "https://example.com/race.json"
@@ -396,9 +398,9 @@ class TestGhGet:
                 for t in threads:
                     t.join()
 
-        assert not errors
-        assert len(results) == 2
-        assert results[0] is results[1]
+        assert not errors  # nosec B101
+        assert len(results) == 2  # nosec B101
+        assert results[0] is results[1]  # nosec B101
 
 
 class TestFetchFolderData:
@@ -411,7 +413,7 @@ class TestFetchFolderData:
         with patch.object(gh_client, "_gh_get", return_value=data):
             result = gh_client.fetch_folder_data(url)
 
-        assert result is data
+        assert result is data  # nosec B101
 
     def test_http_error_includes_status_hint_and_sanitized_url(self):
         url = "https://example.com/folder.json?token=SECRET"
@@ -422,9 +424,9 @@ class TestFetchFolderData:
                 gh_client.fetch_folder_data(url)
 
         msg = str(exc_info.value)
-        assert "TOKEN" in msg
-        assert "SECRET" not in msg
-        assert "example.com/folder.json" in msg
+        assert "TOKEN" in msg  # nosec B101
+        assert "SECRET" not in msg  # nosec B101
+        assert "example.com/folder.json" in msg  # nosec B101
 
     def test_validation_failure_raises_key_error(self):
         url = "https://example.com/folder.json"
@@ -458,7 +460,7 @@ class TestWarmUpCache:
             gh_client.warm_up_cache(urls)
 
         completion.assert_called_once_with("Warming up cache: Done!")
-        assert any("Failed to pre-fetch" in r.message for r in caplog.records)
+        assert any("Failed to pre-fetch" in r.message for r in caplog.records)  # nosec B101
 
     def test_skips_urls_already_in_memory_cache(self, monkeypatch):
         url = "https://example.com/already.json"
@@ -483,5 +485,5 @@ class TestValidateAndFetchUrl:
 
         result = gh_client._validate_and_fetch_url(url)
 
-        assert result is None
+        assert result is None  # nosec B101
         fake_gh_get.assert_not_called()


### PR DESCRIPTION
# refactor(gh_client): split response/error handling and fix Content-Length bug

Closes [ABHI-1634](https://linear.app/abhis-space/issue/ABHI-1634/repo-health-refactor-gh-clientpy-error-and-response-handling-with).

## Summary

Refactored `gh_client.py` so `_gh_get` and `_parse_and_cache_response` are composed of focused, single-responsibility helpers. The only intentional behavior change is the proven `Content-Length` string-matching bug fix. All cache semantics, counter positions, lock ordering, `__all__`, and module-level object identities are preserved.

## What changed

- Split `_parse_and_cache_response` into `_validate_content_type`, `_content_length_exceeds_limit`, `_read_body`, `_parse_json_bytes`, `_build_cache_entry`, and `_record_cache_miss`.
- Split `_gh_get` into `_get_memory_cached`, `_count_blocklist_fetch`, `_serve_disk_ttl_hit`, `_build_conditional_headers`, `_handle_304_with_data`, `_fetch_unconditional`, and `_sanitize_http_status_error`.
- Added `tests/test_gh_client.py` with 28 regression tests covering the required matrix (cache hits, disk TTL, conditional headers, 304 retry, size limits, malformed `Content-Length`, JSON parse errors, HTTP error sanitization, double-checked locking, `warm_up_cache`, and `_validate_and_fetch_url`).
- Updated `CHANGELOG.md` under **Unreleased**.
- Applied `ruff format` to `main.py` to fix a pre-existing `--folder-url` argparse line that was failing `ruff format --check .`.
- Follow-up cleanup: removed the duplicated `Content-Length` parse in `_read_body` by having `_content_length_exceeds_limit` return the parsed size, and made test mocks use `httpx.Headers` plus a chunked `iter_bytes` side-effect for more realistic streaming behavior.

## Verification

```bash
uv run ruff check .
uv run ruff format --check .
uv run mypy main.py models.py validation.py config.py display.py gh_client.py sync.py api_client.py cache.py fix_env.py
uv run pytest tests/ test_main.py -v
```

All pass: `482 passed, 2 subtests passed`.

## Complexity metrics

CodeScene confirmed the improvement on this PR: `gh_client.py` Code Health improved from **8.95 to 9.54**, and all 4 Quality Gates passed. The local proxy metrics below align with that direction.

ABHI-1630 ([GitHub #1094](https://github.com/abhimehro/ctrld-sync/issues/1094)) captured the CodeScene baseline structure but left per-function placeholders and explicitly called out missing observability. The final CodeScene gate for the whole repo-health effort will be verified in **ABHI-1639**.

| Metric | Before (HEAD) | After (this PR) |
|---|---|---|
| `gh_client.py` Code Health (CodeScene) | 8.95 | 9.54 |
| `gh_client.py` SLOC | 198 | 223 |
| `_gh_get` cyclomatic complexity | 12 (radon grade C) | 8 (radon grade B) |
| `_parse_and_cache_response` cyclomatic complexity | 2 | 1 |
| `_gh_get` max nesting depth | 6 | 5 |
| `_parse_and_cache_response` max nesting depth (incl. inner closures) | 6 | 1 |
| Number of functions in `gh_client.py` | 7 | 17 |

The file grew by 25 SLOC, but the two hotspot functions (`_gh_get`, `_parse_and_cache_response`) each dropped in cyclomatic complexity and nesting depth.

## Proven bug fixed

`_read_body` previously parsed `Content-Length` with:

```python
try:
    if int(cl) > config.MAX_RESPONSE_SIZE:
        raise ValueError("Response too large from ...")
except ValueError as e:
    if "Response too large" in str(e):
        raise
    log.warning("Malformed Content-Length header ...")
```

A server returning `Content-Length: Response too large` caused `int()` to raise a `ValueError` whose message contained that substring, so the code re-raised the parse failure as a size-limit error and skipped the streaming fallback. The new `_content_length_exceeds_limit` helper separates parse from comparison and falls back to the streaming `MAX_RESPONSE_SIZE` check for any malformed header.

## Pre-existing issues surfaced, not changed

- `_api_stats["blocklist_fetches"]` is incremented **before** the disk-TTL check, so disk TTL hits still count as fetches. A characterization test (`test_disk_ttl_hit_returns_without_http_and_counts_fetch`) locks this in.
- `_cache_stats` increments are inconsistently locked (e.g., `hits` inside `_cache_lock` on the memory path, `validations`/`errors` outside it). This is benign because the counters are display-only, and adding locks would change lock-acquisition patterns.
- `Content-Type` validation is substring-based (`any(t in ct for t in ...)`), which accepts values like `application/json-evil`. Existing tests pin this permissive behavior.
- `gh_client.USE_COLORS` is imported by value and is **not** forwarded by `main._MainModule.__setattr__` (which only forwards to `display` and `sync`). Tests patch `gh_client.USE_COLORS` directly.
- The 304-without-cached-data retry path returns directly from `_fetch_unconditional`, so the freshly fetched data is written to `_disk_cache` but not promoted into the in-memory `_cache` and bypasses the double-checked `_cache.setdefault`. This is unchanged from the original inline retry and is therefore pre-existing behavior.

## Identity / contract confirmation

- `_gh`, `_cache`, `_cache_lock`, `_disk_cache`, `_cache_stats`, and `_api_stats` are the same module-level objects; no rebinds occurred.
- `__all__` in `gh_client.py` is unchanged.
- `fetch_folder_data`, `warm_up_cache`, `_gh_get`, `_parse_and_cache_response`, and `_validate_and_fetch_url` all remain in `gh_client.py` and use name-based lookup.
- `main.py` continues to re-export `gh_client` symbols; tests that patch `main._gh.stream` in place still pass.

## Security implications

- No secrets, credentials, or `.env` files are introduced.
- All log/raise sites in `gh_client.py` route URL, header, and exception values through `sanitize_for_log`.
- The new test file uses `validation._token` only for redaction assertions and restores it via the autouse `_isolate_client_state` fixture.
- Test assertions are annotated with `# nosec B101` so Bandit does not flag the pytest `assert` statements in the new file.

## Checklist

- [x] Branch follows naming convention
- [x] Commit messages are clear and descriptive
- [x] New code includes relevant tests
- [x] Pre-commit hooks pass
- [x] CHANGELOG updated
- [x] No secrets or credentials included


Link to Devin session: https://app.devin.ai/sessions/ba78159668634f928cfc33d81edcf96f
Requested by: @abhimehro
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/abhimehro/ctrld-sync/pull/1144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->