### PR TITLE
refactor(sync): collapse batch context into _BatchTarget and SyncProfileOptions

### DIFF
--- a/.agents/skills/testing-ctrld-sync/SKILL.md
+++ b/.agents/skills/testing-ctrld-sync/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: testing-ctrld-sync
-description: Test the ctrld-sync Python CLI end-to-end. Use when validating CLI dry-run behavior, folder URL validation, SSRF safety checks, or sync planning changes.
+description: Test the ctrld-sync Python CLI end-to-end, including dry-run planning, SSRF harnesses, and batching regression checks.
 ---
 
 # ctrld-sync CLI Testing
@@ -32,7 +32,7 @@ Dry-run and mocked SSRF validation tests do not require Control D secrets.
 ## Standard verification commands
 
 ```bash
-uv run pytest tests/ -v
+uv run pytest tests/ test_main.py -v
 uv run ruff check .
 uv run mypy main.py
 uv run pre-commit run --all-files
@@ -49,7 +49,7 @@ uv run mypy main.py
 
 ## Runtime dry-run testing
 
-The documented safe runtime path is:
+The simplest dry-run sanity command is:
 
 ```bash
 uv run python main.py --dry-run --folder-url https://example.com/config.json
@@ -58,12 +58,26 @@ uv run python main.py --dry-run --folder-url https://example.com/config.json
 `--dry-run` does not require `TOKEN` or `PROFILE`; `main.py` uses a
 `dry-run-placeholder` profile and avoids Control D API writes.
 
+Important: `example.com` is **not** in the default `allowed_blocklist_domains`
+(`raw.githubusercontent.com`, `github.com`, `yokoffing.github.io`), so the
+command above will print a `DRY RUN SUMMARY` but exit `1` with
+`Failed (Dry)`. It does not crash, but it does not produce a `Ready` status.
+To obtain a passing `Planned` / `Ready` dry-run, either:
+
+- use a URL whose host is in the default allowlist, or
+- create a temporary `config.yaml` with `allowed_blocklist_domains: [example.com]`
+  and pass `--config /path/to/config.yaml`.
+
+## SSRF harness for mocked end-to-end dry-run
+
 For deterministic SSRF tests, use a temporary Python harness that:
 
 1. Calls `main.main()` with `--dry-run` and explicit `--folder-url` values.
 2. Patches `socket.getaddrinfo` to return controlled IP addresses.
-3. Patches `main._gh_get` so unsafe URLs fail immediately if fetched and safe
-   URLs return minimal valid folder JSON.
+3. Patches **`gh_client._gh_get`** (not `main._gh_get`) so unsafe URLs fail
+   immediately if fetched and safe URLs return minimal valid folder JSON.
+   `main._gh_get` is just an alias; the actual fetch path goes through
+   `gh_client.fetch_folder_data` -> `gh_client._gh_get`.
 4. Does not patch `main.main()`, `sync_profile()`, `validate_folder_url()`,
    `validate_hostname()`, or `_is_safe_ip()`.
 5. Attaches an explicit in-memory handler to logger `control-d-sync`; the
@@ -71,6 +85,11 @@ For deterministic SSRF tests, use a temporary Python harness that:
    `contextlib.redirect_stderr()` alone might not capture warnings.
 6. Patches `main.prompt_for_interactive_restart` to a no-op when running in a
    PTY so dry-run success does not block on the restart prompt.
+7. Patches `main.load_disk_cache` and `main.load_dotenv` to no-ops so the
+   harness starts from a clean, reproducible state.
+8. Clears `main.validate_folder_url.cache_clear()`,
+   `main.validate_hostname.cache_clear()`, `gh_client._cache`, and
+   `gh_client._disk_cache` before the run.
 
 Useful SSRF cases:
 
@@ -81,13 +100,23 @@ Useful SSRF cases:
   `is_reserved` guard blocks a reserved IPv6 address that may otherwise report
   `is_global=True`.
 
-Expected dry-run evidence for a passing one-folder safe case:
+Expected dry-run evidence for a passing safe case:
 
 - Output contains `DRY RUN SUMMARY`.
 - Output includes the accepted folder name.
-- Summary shows `1` folder, `1` rule, `Planned`, and `Ready`.
+- Summary shows at least one folder / one rule with status `Planned` and `Ready`.
 - Captured logger output contains unsafe-host warnings for rejected cases.
-- Fetched URL list contains only the safe URL.
+- Fetched URL list contains only the safe URL(s).
+- `api_client._api_stats["control_d_api_calls"]` remains `0` after the run.
+
+## No-live-API guard
+
+When proving that `--dry-run` does not call the Control D API:
+
+- Patch `sync.create_client` to raise `AssertionError` if invoked.
+- Check `api_client._api_stats["control_d_api_calls"]` at the end of the run.
+- The only HTTP traffic in dry-run mode should be blocklist fetches for
+  allowlisted `--folder-url` values (mocked in the harness).
 
 ## Notes
 

--- a/main.py
+++ b/main.py
@@ -135,6 +135,7 @@ from models import (  # noqa: F401
     RuleEntry,
     RuleGroup,
     SyncContext,
+    SyncProfileOptions,
     SyncResult,
 )
 from sync import (  # noqa: F401
@@ -677,12 +678,14 @@ def main() -> bool:
             )
             log.info("Starting sync for profile %s", display_profile)
             status = sync_profile(
-                profile_id,
-                folder_urls,
-                token=TOKEN or "",
-                dry_run=args.dry_run,
-                no_delete=args.no_delete,
-                plan_accumulator=plan,
+                SyncProfileOptions(
+                    profile_id=profile_id,
+                    folder_urls=folder_urls,
+                    token=TOKEN or "",
+                    dry_run=args.dry_run,
+                    no_delete=args.no_delete,
+                    plan_accumulator=plan,
+                )
             )
             end_time = time.time()
             duration = end_time - start_time

--- a/models.py
+++ b/models.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import concurrent.futures
 import httpx
 from dataclasses import dataclass
+from collections.abc import Sequence
 from typing import NotRequired, TypedDict
 
 
@@ -24,6 +25,19 @@ class SyncContext:
     client: httpx.Client
     existing_rules: set[str]
     batch_executor: concurrent.futures.Executor | None = None
+
+
+@dataclass(frozen=True)
+class SyncProfileOptions:
+    """Top-level options for a profile sync run."""
+
+    profile_id: str
+    folder_urls: Sequence[str]
+    token: str
+    dry_run: bool = False
+    no_delete: bool = False
+    # plan_accumulator is intentionally a mutable out-parameter (sink).
+    plan_accumulator: list[PlanEntry] | None = None
 
 
 class FolderAction(TypedDict, total=False):
@@ -107,6 +121,7 @@ class SyncResult(TypedDict):
 __all__ = [
     "RuleAction",
     "SyncContext",
+    "SyncProfileOptions",
     "FolderAction",
     "FolderGroup",
     "RuleEntry",

--- a/sync.py
+++ b/sync.py
@@ -9,6 +9,7 @@ import logging
 import sys
 import time
 from collections.abc import Sequence
+from dataclasses import dataclass
 
 
 import httpx
@@ -34,7 +35,7 @@ from display import (
     render_progress_bar,
 )
 from gh_client import _cache, _cache_lock, fetch_folder_data  # noqa: F401
-from models import FolderData, PlanEntry, RuleAction, SyncContext
+from models import FolderData, PlanEntry, RuleAction, SyncContext, SyncProfileOptions
 from validation import (
     _ALLOWED_RULE_CHARS,
     MAX_RULE_LENGTH,
@@ -47,6 +48,63 @@ from validation import (
 )
 
 log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class _BatchTarget:
+    """Per-folder invariants for a batched rule push."""
+
+    profile_id: str
+    sanitized_name: str
+    str_do: str
+    str_status: str
+    str_group: str
+    progress_label: str
+
+    @classmethod
+    def from_parts(
+        cls,
+        profile_id: str,
+        folder_name: str,
+        folder_id: str,
+        action: RuleAction,
+    ) -> _BatchTarget:
+        sanitized_name = sanitize_for_log(folder_name)
+        return cls(
+            profile_id=profile_id,
+            sanitized_name=sanitized_name,
+            str_do=str(action.do),
+            str_status=str(action.status),
+            str_group=str(folder_id),
+            progress_label=f"Folder {sanitized_name}",
+        )
+
+
+def _managed_batch_executor(
+    ctx: SyncContext,
+) -> contextlib.AbstractContextManager[concurrent.futures.Executor]:
+    """Return a context manager for the batch executor.
+
+    Reuses an externally provided executor when available; otherwise creates a
+    fresh ThreadPoolExecutor with max_workers=4 that is shut down on exit.
+    """
+    if ctx.batch_executor is not None:
+        return contextlib.nullcontext(ctx.batch_executor)
+    return concurrent.futures.ThreadPoolExecutor(max_workers=4)
+
+
+def _run_single_batch(
+    ctx: SyncContext,
+    target: _BatchTarget,
+    batch: list[str],
+) -> int:
+    """Push a single batch synchronously and update state."""
+    result = _push_single_batch(ctx.client, target, 1, batch)
+    successful_batches = 1 if result else 0
+    if result:
+        ctx.existing_rules.update(result)
+    render_progress_bar(successful_batches, 1, target.progress_label)
+    return successful_batches
 
 
 def create_client(token: str) -> httpx.Client:
@@ -540,30 +598,28 @@ def _filter_rules_for_folder(
 
 def _push_single_batch(
     client: httpx.Client,
-    profile_id: str,
-    sanitized_folder_name: str,
-    str_do: str,
-    str_status: str,
-    str_group: str,
+    target: _BatchTarget,
     batch_idx: int,
     batch_data: list[str],
 ) -> list[str] | None:
-    """Processes a single batch of rules by sending API request."""
+    """Process a single batch of rules by sending an API request."""
     data = {
-        "do": str_do,
-        "status": str_status,
-        "group": str_group,
+        "do": target.str_do,
+        "status": target.str_status,
+        "group": target.str_group,
     }
     # Optimization: Use pre-calculated keys and zip for faster dict update
     # strict=False is intentional: batch_data may be shorter than BATCH_KEYS for final batch
     data.update(zip(config.BATCH_KEYS, batch_data, strict=False))
 
     try:
-        _api_post_form(client, f"{config.API_BASE}/{profile_id}/rules", data=data)
+        _api_post_form(
+            client, f"{config.API_BASE}/{target.profile_id}/rules", data=data
+        )
         if not USE_COLORS:
             log.info(
                 "Folder %s – batch %d: added %d %s",
-                sanitized_folder_name,
+                target.sanitized_name,
                 batch_idx,
                 len(batch_data),
                 pluralize(len(batch_data), "rule"),
@@ -577,7 +633,7 @@ def _push_single_batch(
             status_code = e.response.status_code
             hint = f" ({config._STATUS_HINTS.get(status_code, f'HTTP {status_code}')})"
         log.error(
-            f"Failed to push batch {batch_idx} for folder {sanitized_folder_name}{hint}: {sanitize_for_log(e)}"
+            f"Failed to push batch {batch_idx} for folder {target.sanitized_name}{hint}: {sanitize_for_log(e)}"
         )
         response = getattr(e, "response", None)
         if response is not None and log.isEnabledFor(logging.DEBUG):
@@ -588,24 +644,13 @@ def _push_single_batch(
 def _process_batches_with_executor(
     executor: concurrent.futures.Executor,
     ctx: SyncContext,
-    batch_config: tuple[tuple[str, str, str, str], list[list[str]], str],
+    target: _BatchTarget,
+    batches: list[list[str]],
 ) -> int:
     """Process batches using the provided executor and return successful batch count."""
-    batch_params, batches, progress_label = batch_config
-    str_do, str_status, str_group, sanitized_folder_name = batch_params
     successful_batches = 0
     futures = {
-        executor.submit(
-            _push_single_batch,
-            ctx.client,
-            ctx.profile_id,
-            sanitized_folder_name,
-            str_do,
-            str_status,
-            str_group,
-            i,
-            batch,
-        ): i
+        executor.submit(_push_single_batch, ctx.client, target, i, batch): i
         for i, batch in enumerate(batches, 1)
     }
 
@@ -615,13 +660,13 @@ def _process_batches_with_executor(
             successful_batches += 1
             ctx.existing_rules.update(result)
 
-        render_progress_bar(successful_batches, len(batches), progress_label)
+        render_progress_bar(successful_batches, len(batches), target.progress_label)
 
     return successful_batches
 
 
 def _log_batch_result(
-    sanitized_folder_name: str,
+    target: _BatchTarget,
     successful_batches: int,
     total_batches: int,
     total_rules: int,
@@ -629,7 +674,7 @@ def _log_batch_result(
     """Helper to evaluate and log the result of a batch rule push."""
     if successful_batches == total_batches:
         _print_completion(
-            f"Folder {sanitized_folder_name}: Finished ({total_rules:,} {pluralize(total_rules, 'rule')})"
+            f"Folder {target.sanitized_name}: Finished ({total_rules:,} {pluralize(total_rules, 'rule')})"
         )
         return True
 
@@ -637,14 +682,14 @@ def _log_batch_result(
     if successful_batches > 0:
         log.warning(
             "Folder %s – only %d/%d batches succeeded (Partial)",
-            sanitized_folder_name,
+            target.sanitized_name,
             successful_batches,
             total_batches,
         )
     else:
         log.error(
             "Folder %s – 0/%d batches succeeded",
-            sanitized_folder_name,
+            target.sanitized_name,
             total_batches,
         )
     return False
@@ -652,9 +697,7 @@ def _log_batch_result(
 
 def _push_rule_batches(
     ctx: SyncContext,
-    folder_name: str,
-    folder_id: str,
-    action: RuleAction,
+    target: _BatchTarget,
     filtered_hostnames: list[str],
 ) -> bool:
     """
@@ -666,46 +709,16 @@ def _push_rule_batches(
     ]
     total_batches = len(batches)
 
-    # Optimization: Hoist loop invariants to avoid redundant computations
-    str_do = str(action.do)
-    str_status = str(action.status)
-    str_group = str(folder_id)
-    sanitized_folder_name = sanitize_for_log(folder_name)
-    progress_label = f"Folder {sanitized_folder_name}"
-
-    # Optimization 3: Parallelize batch processing
-    batch_params = (str_do, str_status, str_group, sanitized_folder_name)
-    batch_config = (batch_params, batches, progress_label)
-
     if total_batches == 1:
-        result = _push_single_batch(
-            ctx.client,
-            ctx.profile_id,
-            sanitized_folder_name,
-            str_do,
-            str_status,
-            str_group,
-            1,
-            batches[0],
-        )
-        successful_batches = 1 if result else 0
-        if result:
-            ctx.existing_rules.update(result)
-        render_progress_bar(successful_batches, 1, progress_label)
+        successful_batches = _run_single_batch(ctx, target, batches[0])
     else:
-        if ctx.batch_executor:
-            with contextlib.nullcontext(ctx.batch_executor) as executor:
-                successful_batches = _process_batches_with_executor(
-                    executor, ctx, batch_config
-                )
-        else:
-            with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
-                successful_batches = _process_batches_with_executor(
-                    executor, ctx, batch_config
-                )
+        with _managed_batch_executor(ctx) as executor:
+            successful_batches = _process_batches_with_executor(
+                executor, ctx, target, batches
+            )
 
     return _log_batch_result(
-        sanitized_folder_name,
+        target,
         successful_batches,
         total_batches,
         len(filtered_hostnames),
@@ -740,13 +753,8 @@ def push_rules(
         )
         return True
 
-    return _push_rule_batches(
-        ctx,
-        folder_name,
-        folder_id,
-        action,
-        filtered_hostnames,
-    )
+    target = _BatchTarget.from_parts(ctx.profile_id, folder_name, folder_id, action)
+    return _push_rule_batches(ctx, target, filtered_hostnames)
 
 
 def _process_single_folder(
@@ -968,14 +976,72 @@ def _prepare_folders_and_rules(
     return existing_folders, existing_rules
 
 
-def sync_profile(
-    profile_id: str,
-    folder_urls: Sequence[str],
-    token: str,
-    dry_run: bool = False,
-    no_delete: bool = False,
-    plan_accumulator: list[PlanEntry] | None = None,
+def _sync_profile_live(
+    options: SyncProfileOptions,
+    folder_data_list: list[FolderData],
 ) -> bool:
+    """Execute the live (non-dry-run) portion of a profile sync."""
+    with (
+        concurrent.futures.ThreadPoolExecutor(
+            max_workers=config.DELETE_WORKERS
+        ) as shared_executor,
+        create_client(options.token) as client,
+    ):
+        existing_folders_and_rules = _prepare_folders_and_rules(
+            client,
+            options.profile_id,
+            folder_data_list,
+            options.no_delete,
+            shared_executor,
+        )
+        if existing_folders_and_rules[0] is None:
+            return False
+        existing_folders, existing_rules = existing_folders_and_rules
+
+        ctx = SyncContext(
+            profile_id=options.profile_id,
+            client=client,
+            existing_rules=existing_rules,
+            batch_executor=shared_executor,
+        )
+
+        success_count = _process_folders(ctx, folder_data_list)
+
+    log.info(
+        f"Sync complete: {success_count}/{len(folder_data_list)} {pluralize(len(folder_data_list), 'folder')} processed successfully"
+    )
+    return success_count == len(folder_data_list)
+
+
+def _process_folders(
+    ctx: SyncContext,
+    folder_data_list: list[FolderData],
+) -> int:
+    """Process folders serially (max_workers=1) and return the success count."""
+    success_count = 0
+    # CRITICAL FIX: Switch to Serial Processing (1 worker)
+    # This prevents API rate limits and ensures stability for large folders.
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        future_to_folder = {
+            executor.submit(_process_single_folder, ctx, folder_data): folder_data
+            for folder_data in folder_data_list
+        }
+
+        for future in concurrent.futures.as_completed(future_to_folder):
+            folder_data = future_to_folder[future]
+            folder_name = folder_data["group"]["group"].strip()
+            try:
+                if future.result():
+                    success_count += 1
+            except Exception as e:
+                log.error(
+                    f"Failed to process folder '{sanitize_for_log(folder_name)}': {sanitize_for_log(e)}"
+                )
+
+    return success_count
+
+
+def sync_profile(options: SyncProfileOptions) -> bool:
     """
     Synchronizes Control D folders from remote blocklist URLs.
 
@@ -990,81 +1056,26 @@ def sync_profile(
     validate_hostname.cache_clear()
 
     try:
-        folder_data_list = _fetch_all_folder_data(folder_urls)
+        folder_data_list = _fetch_all_folder_data(options.folder_urls)
         if folder_data_list is None:
             return False
 
         # Build plan entries
-        plan_entry = _build_plan_entry(profile_id, folder_data_list)
+        plan_entry = _build_plan_entry(options.profile_id, folder_data_list)
 
-        if plan_accumulator is not None:
-            plan_accumulator.append(plan_entry)
+        if options.plan_accumulator is not None:
+            options.plan_accumulator.append(plan_entry)
 
-        if dry_run:
+        if options.dry_run:
             print_plan_details(plan_entry)
             log.info("Dry-run complete: no API calls were made.")
             return True
 
-        # Create new folders and push rules
-        success_count = 0
-
-        # CRITICAL FIX: Switch to Serial Processing (1 worker)
-        # This prevents API rate limits and ensures stability for large folders.
-        max_workers = 1
-
-        # Shared executor for rate-limited operations (DELETE, push_rules batches)
-        # Reusing this executor prevents thread churn and enforces global rate limits.
-        with (
-            concurrent.futures.ThreadPoolExecutor(
-                max_workers=config.DELETE_WORKERS
-            ) as shared_executor,
-            create_client(token) as client,
-        ):
-            existing_folders_and_rules = _prepare_folders_and_rules(
-                client, profile_id, folder_data_list, no_delete, shared_executor
-            )
-            if existing_folders_and_rules[0] is None:
-                return False
-            existing_folders, existing_rules = existing_folders_and_rules
-
-            ctx = SyncContext(
-                profile_id=profile_id,
-                client=client,
-                existing_rules=existing_rules,
-                batch_executor=shared_executor,
-            )
-
-            with concurrent.futures.ThreadPoolExecutor(
-                max_workers=max_workers
-            ) as executor:
-                future_to_folder = {
-                    executor.submit(
-                        _process_single_folder,
-                        ctx,
-                        folder_data,
-                    ): folder_data
-                    for folder_data in folder_data_list
-                }
-
-                for future in concurrent.futures.as_completed(future_to_folder):
-                    folder_data = future_to_folder[future]
-                    folder_name = folder_data["group"]["group"].strip()
-                    try:
-                        if future.result():
-                            success_count += 1
-                    except Exception as e:
-                        log.error(
-                            f"Failed to process folder '{sanitize_for_log(folder_name)}': {sanitize_for_log(e)}"
-                        )
-
-        log.info(
-            f"Sync complete: {success_count}/{len(folder_data_list)} {pluralize(len(folder_data_list), 'folder')} processed successfully"
-        )
-        return success_count == len(folder_data_list)
+        return _sync_profile_live(options, folder_data_list)
 
     except Exception as e:
         log.error(
-            f"Unexpected error during sync for profile {profile_id}: {sanitize_for_log(e)}"
+            f"Unexpected error during sync for profile {options.profile_id}: {sanitize_for_log(e)}"
         )
         return False
 

--- a/test_main.py
+++ b/test_main.py
@@ -474,7 +474,7 @@ def test_interactive_input_extracts_id(monkeypatch, capsys):
 
     # Verify sync_profile called with extracted ID
     args, _ = mock_sync.call_args
-    assert args[0] == "extracted_id"
+    assert args[0].profile_id == "extracted_id"
 
     # Verify prompt text update
     captured = capsys.readouterr()

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -81,3 +81,20 @@ def test_push_rules_creates_executor_when_none(
     assert mock_tpe_cls.called, (
         "ThreadPoolExecutor should be created when batch_executor is None"
     )
+
+
+def test_sync_profile_options_defaults_and_field_rebinding_is_blocked(main_module):
+    """SyncProfileOptions exposes expected defaults and rejects field rebinding."""
+    options = main_module.SyncProfileOptions(
+        profile_id="p1",
+        folder_urls=["url"],
+        token="tok",
+    )
+    assert options.dry_run is False
+    assert options.no_delete is False
+    assert options.plan_accumulator is None
+
+    # plan_accumulator is intentionally a mutable out-parameter (sink).
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        # Use setattr so static type checkers do not flag a frozen-field assignment.
+        setattr(options, "profile_id", "p2")

--- a/tests/test_parallel_deletion.py
+++ b/tests/test_parallel_deletion.py
@@ -92,7 +92,12 @@ def test_parallel_deletion_uses_threadpool(mock_env, monkeypatch):
 
     with patch("concurrent.futures.ThreadPoolExecutor", TrackedExecutor):
         main.sync_profile(
-            "test-profile", ["url1", "url2"], token=TEST_TOKEN, no_delete=False
+            main.SyncProfileOptions(
+                profile_id="test-profile",
+                folder_urls=["url1", "url2"],
+                token=TEST_TOKEN,
+                no_delete=False,
+            )
         )
 
     # Verify ThreadPoolExecutor was called with DELETE_WORKERS
@@ -156,7 +161,14 @@ def test_parallel_deletion_handles_exceptions(mock_env, monkeypatch):
     monkeypatch.setattr(main.log, "error", mock_error)
 
     # Should not crash, should log error
-    main.sync_profile("test-profile", ["url"], token=TEST_TOKEN, no_delete=False)
+    main.sync_profile(
+        main.SyncProfileOptions(
+            profile_id="test-profile",
+            folder_urls=["url"],
+            token=TEST_TOKEN,
+            no_delete=False,
+        )
+    )
 
     # Verify error was logged
     assert len(log_calls) > 0, "Expected error to be logged"
@@ -211,7 +223,14 @@ def test_parallel_deletion_sanitizes_exception(mock_env, monkeypatch):
     monkeypatch.setattr(main.log, "error", mock_error)
 
     # Run sync
-    main.sync_profile("test-profile", ["url"], token=TEST_TOKEN, no_delete=False)
+    main.sync_profile(
+        main.SyncProfileOptions(
+            profile_id="test-profile",
+            folder_urls=["url"],
+            token=TEST_TOKEN,
+            no_delete=False,
+        )
+    )
 
     # Verify TOKEN was redacted and control chars were escaped
     assert len(log_calls) > 0

--- a/tests/test_push_rules_perf.py
+++ b/tests/test_push_rules_perf.py
@@ -3,6 +3,8 @@ import sys
 import unittest
 from unittest.mock import MagicMock, patch
 
+import httpx
+
 # Add root to path to import main
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -182,6 +184,156 @@ class TestPushRulesPerf(unittest.TestCase):
 
         # Verify executor.submit was called twice (once for each batch)
         self.assertEqual(mock_executor.submit.call_count, 2)
+
+    @patch("sync._api_post_form")
+    def test_push_rules_partial_failure_updates_existing_rules(self, mock_api_post):
+        """A failed batch leaves successful batches in existing_rules."""
+        batch_size = self.main.BATCH_SIZE
+        hostnames = [f"example{i}.com" for i in range(batch_size)] + ["bad.com"]
+
+        def side_effect(client, url, data=None):
+            if data and data.get("hostnames[0]") == "bad.com":
+                raise httpx.RequestError("boom")
+            return MagicMock(spec=httpx.Response)
+
+        mock_api_post.side_effect = side_effect
+
+        ctx = self.main.SyncContext(
+            profile_id=self.profile_id,
+            client=self.client,
+            existing_rules=set(),
+        )
+        action = self.main.RuleAction(do=self.do, status=self.status)
+
+        with self.assertLogs("control-d-sync", level="WARNING") as cm:
+            result = self.main.push_rules(
+                ctx,
+                self.folder_name,
+                self.folder_id,
+                action,
+                hostnames,
+            )
+
+        self.assertFalse(result)
+        self.assertEqual(len(ctx.existing_rules), batch_size)
+        self.assertNotIn("bad.com", ctx.existing_rules)
+        self.assertTrue(
+            any("only 1/2 batches succeeded (Partial)" in m for m in cm.output),
+            f"Expected partial-failure log, got: {cm.output}",
+        )
+
+    @patch("sync._api_post_form")
+    def test_push_rules_total_failure_logs_zero_batches(self, mock_api_post):
+        """All failed batches return False and log the total failure."""
+        hostnames = [f"example{i}.com" for i in range(600)]
+        mock_api_post.side_effect = httpx.RequestError("boom")
+
+        ctx = self.main.SyncContext(
+            profile_id=self.profile_id,
+            client=self.client,
+            existing_rules=set(),
+        )
+        action = self.main.RuleAction(do=self.do, status=self.status)
+
+        with self.assertLogs("control-d-sync", level="ERROR") as cm:
+            result = self.main.push_rules(
+                ctx,
+                self.folder_name,
+                self.folder_id,
+                action,
+                hostnames,
+            )
+
+        self.assertFalse(result)
+        self.assertEqual(len(ctx.existing_rules), 0)
+        self.assertTrue(
+            any("0/2 batches succeeded" in m for m in cm.output),
+            f"Expected total-failure log, got: {cm.output}",
+        )
+
+    @patch("sync.concurrent.futures.as_completed")
+    def test_push_rules_provided_executor_is_not_shut_down(self, mock_as_completed):
+        """An externally supplied executor must not be shut down or exited."""
+        batch_size = self.main.BATCH_SIZE
+        hostnames = [f"example{i}.com" for i in range(batch_size + 1)]
+
+        mock_executor = MagicMock()
+        mock_future_1 = MagicMock()
+        mock_future_1.result.return_value = hostnames[:batch_size]
+        mock_future_2 = MagicMock()
+        mock_future_2.result.return_value = hostnames[batch_size:]
+        mock_executor.submit.side_effect = [mock_future_1, mock_future_2]
+        mock_as_completed.return_value = [mock_future_1, mock_future_2]
+
+        ctx = self.main.SyncContext(
+            profile_id=self.profile_id,
+            client=self.client,
+            existing_rules=set(),
+            batch_executor=mock_executor,
+        )
+        action = self.main.RuleAction(do=self.do, status=self.status)
+
+        with patch("sync._api_post_form"):
+            result = self.main.push_rules(
+                ctx,
+                self.folder_name,
+                self.folder_id,
+                action,
+                hostnames,
+            )
+
+        self.assertTrue(result)
+        self.assertEqual(mock_executor.submit.call_count, 2)
+        mock_executor.shutdown.assert_not_called()
+        mock_executor.__exit__.assert_not_called()
+
+    @patch("sync._api_post_form")
+    def test_push_rules_short_final_batch(self, mock_api_post):
+        """A final batch smaller than BATCH_SIZE emits only one hostnames[0] key."""
+        batch_size = self.main.BATCH_SIZE
+        hostnames = [f"example{i}.com" for i in range(batch_size)] + ["final.com"]
+        payloads: list[dict] = []
+
+        def side_effect(client, url, data=None):
+            if data is not None:
+                payloads.append(data.copy())
+            return MagicMock(spec=httpx.Response)
+
+        mock_api_post.side_effect = side_effect
+
+        ctx = self.main.SyncContext(
+            profile_id=self.profile_id,
+            client=self.client,
+            existing_rules=set(),
+        )
+        action = self.main.RuleAction(do=self.do, status=self.status)
+
+        result = self.main.push_rules(
+            ctx,
+            self.folder_name,
+            self.folder_id,
+            action,
+            hostnames,
+        )
+
+        self.assertTrue(result)
+        self.assertEqual(len(payloads), 2)
+
+        hostname_key_counts = [
+            len([k for k in p if k.startswith("hostnames[")]) for p in payloads
+        ]
+        self.assertIn(batch_size, hostname_key_counts)
+        self.assertIn(1, hostname_key_counts)
+
+        short_payloads = [
+            p
+            for p in payloads
+            if len([k for k in p if k.startswith("hostnames[")]) == 1
+        ]
+        self.assertEqual(len(short_payloads), 1)
+        short_payload = short_payloads[0]
+        self.assertEqual(short_payload["hostnames[0]"], "final.com")
+        self.assertNotIn("hostnames[1]", short_payload)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes ABHI-1635.

## What Changed and Why

Reduced CodeScene-measured argument-count/complexity debt in `sync.py` batching and `sync_profile` context plumbing while preserving behavior:

- Introduced `SyncProfileOptions` in `models.py` and changed `sync_profile` to a single-argument entry point.
- Replaced the 8-argument `_push_single_batch` with a frozen, slots `_BatchTarget` dataclass, constructed once per `push_rules` call.
- Collapsed `_push_rule_batches` and `_process_batches_with_executor` around `_BatchTarget`, eliminating per-batch tuple packing.
- Added `_managed_batch_executor` as a plain context-manager factory and `_run_single_batch` helper, keeping `max_workers=4` hardcoded and keyword-form.
- Extracted `_sync_profile_live` and `_process_folders` from `sync_profile` while keeping `cache_clear()` and the top-level `except Exception` wrapper in `sync_profile`.
- Kept `push_rules` public signature unchanged; updated `main.py` and tests to wrap calls in `SyncProfileOptions(...)`.
- Added four regression tests: multi-batch partial failure, total failure, provided executor not shut down, and short final batch payload.

## Verification

- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed
- `uv run mypy main.py models.py validation.py config.py display.py gh_client.py sync.py api_client.py cache.py fix_env.py` — passed
- `uv run pytest tests/ test_main.py -q` — 487 passed
- `uv run pytest --cov --cov-report=term` — 71.72% coverage, required 55% reached
- Benchmark comparison against `main` baseline with `--benchmark-compare=0001_base --benchmark-compare-fail=mean:10%` — passed

Link to Devin session: https://app.devin.ai/sessions/b9222e0fe0d0404ea909e77e460da161
Requested by: @abhimehro