### PR TITLE
🛡️ Sentinel: [MEDIUM] Replace insecure random module with secrets

### DIFF
--- a/api_client.py
+++ b/api_client.py
@@ -22,7 +22,7 @@ the signature ``(Any) -> str`` is accepted.
 from __future__ import annotations
 
 import logging
-import random
+import secrets
 import threading
 import time
 from collections.abc import Callable
@@ -243,7 +243,7 @@ def retry_with_jitter(
         Delay in seconds with full jitter applied
     """
     exponential_delay = min(base_delay * (2.0**attempt), max_delay)
-    return exponential_delay * random.random()
+    return exponential_delay * secrets.SystemRandom().random()
 
 
 def _is_server_error(e: Exception) -> bool:

--- a/benchmark_retry_jitter.py
+++ b/benchmark_retry_jitter.py
@@ -8,7 +8,7 @@ deterministic exponential backoff.
 Usage: python3 benchmark_retry_jitter.py
 """
 
-import random
+import secrets
 
 
 def simulate_retries_without_jitter(max_retries: int, base_delay: float) -> list[float]:
@@ -25,7 +25,7 @@ def simulate_retries_with_jitter(max_retries: int, base_delay: float) -> list[fl
     delays = []
     for attempt in range(max_retries - 1):
         base_wait = base_delay * (2**attempt)
-        jitter_factor = 0.5 + random.random()  # [0.5, 1.5]
+        jitter_factor = 0.5 + secrets.SystemRandom().random()  # [0.5, 1.5]
         wait_time = base_wait * jitter_factor
         delays.append(wait_time)
     return delays
@@ -95,7 +95,7 @@ def main():
     # Simulate retry distribution
     retry_times = []
     for _ in range(num_clients):
-        first_retry = base_delay * (0.5 + random.random())
+        first_retry = base_delay * (0.5 + secrets.SystemRandom().random())
         retry_times.append(first_retry)
 
     retry_times.sort()

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -246,7 +246,7 @@ class TestRetryWithRateLimit:
         with main._rate_limit_lock:
             assert main._rate_limit_info["remaining"] == 50
 
-    @patch("random.random", return_value=1.0)
+    @patch("secrets.SystemRandom.random", return_value=1.0)
     def test_429_without_retry_after_uses_exponential_backoff(self, mock_random):
         """Test that 429 without Retry-After falls back to exponential backoff."""
         mock_request = MagicMock()
@@ -268,7 +268,7 @@ class TestRetryWithRateLimit:
 
         request_func = MagicMock(side_effect=[error, error, success_response])
 
-        # With delay=1 and random.random()=1.0 (full jitter), backoff is: 1s, 2s
+        # With delay=1 and SystemRandom.random()=1.0 (full jitter), backoff is: 1s, 2s
         # Total wait should be >= 3 seconds
         start_time = time.time()
         result = main.api_client._retry_request(request_func, max_retries=3, delay=1)

--- a/tests/test_retry_jitter.py
+++ b/tests/test_retry_jitter.py
@@ -36,7 +36,7 @@ class TestRetryJitter:
 
         # Deterministic randomness check: patch RNG to return two different values
         # so we can assert that jitter actually affects the delay without flakiness.
-        with patch("main.api_client.random.random", side_effect=[0.1, 0.9]):
+        with patch("secrets.SystemRandom.random", side_effect=[0.1, 0.9]):
             delay_1 = main.api_client.retry_with_jitter(2)
             delay_2 = main.api_client.retry_with_jitter(2)
 
@@ -102,16 +102,16 @@ class TestRetryJitter:
     def test_exponential_backoff_still_increases(self):
         """Verify that despite jitter, the exponential base scaling is correct.
 
-        We fix random.random() to a constant so that jitter becomes deterministic,
+        We fix SystemRandom.random() to a constant so that jitter becomes deterministic,
         and then assert that each delay matches delay * 2**attempt * random_factor.
         """
         request_func = Mock(side_effect=httpx.TimeoutException("Connection timeout"))
 
-        # Full jitter is implemented as: min(base_delay * 2**attempt, MAX_RETRY_DELAY) * random.random()
-        # With random.random() fixed at 0.5, each delay = exponential_delay * 0.5.
+        # Full jitter is implemented as: min(base_delay * 2**attempt, MAX_RETRY_DELAY) * SystemRandom.random()
+        # With SystemRandom.random() fixed at 0.5, each delay = exponential_delay * 0.5.
         with (
             patch("time.sleep") as mock_sleep,
-            patch("random.random", return_value=0.5),
+            patch("secrets.SystemRandom.random", return_value=0.5),
         ):
             with contextlib.suppress(httpx.TimeoutException):
                 main.api_client._retry_request(request_func, max_retries=5, delay=1)
@@ -121,7 +121,9 @@ class TestRetryJitter:
             for attempt, wait_time in enumerate(wait_times):
                 base_delay = 1 * (2**attempt)
                 exponential_delay = min(base_delay, main.api_client.MAX_RETRY_DELAY)
-                expected_delay = exponential_delay * 0.5  # random.random() fixed at 0.5
+                expected_delay = (
+                    exponential_delay * 0.5
+                )  # SystemRandom.random() fixed at 0.5
                 # Use approx to avoid brittle float equality while still being strict.
                 assert wait_time == pytest.approx(expected_delay), (
                     f"Attempt {attempt}: expected {expected_delay:.2f}s, "
@@ -162,7 +164,7 @@ class TestRetryJitter:
             wait_times = [call.args[0] for call in mock_sleep.call_args_list]
             assert len(wait_times) == 2
 
-            # First retry: full jitter, base=1, range=[0, 1.0) since random.random() < 1.0
+            # First retry: full jitter, base=1, range=[0, 1.0) since SystemRandom.random() < 1.0
             assert 0.0 <= wait_times[0] < 1.0
 
     def test_successful_retry_after_transient_failure(self):


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The codebase uses the insecure `random` module for pseudo-random number generation (PRNG) instead of the cryptographically secure `secrets` module. This violates the security standard documented in the project.
🎯 Impact: While currently used for jitter, using insecure PRNGs can lead to predictability in timing or other randomized behaviors. More importantly, it triggers security linters (like Bandit B311) and sets a bad precedent for future development where `random` might be used in a security-sensitive context.
🔧 Fix: Replaced all instances of `random.random()` with `secrets.SystemRandom().random()` and updated imports from `random` to `secrets` in `api_client.py` and `benchmark_retry_jitter.py`. Fixed tests that mocked `random.random()`.
✅ Verification: Ran the full test suite and `benchmark_retry_jitter.py` to verify that the jitter behavior remains functionally identical and that security linters are satisfied.

---
*PR created automatically by Jules for task [5669875283262862443](https://jules.google.com/task/5669875283262862443) started by @abhimehro*