### PR TITLE
🎨 Palette: Grammatical Polish for Dry Run Errors

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -295,3 +295,7 @@ context flags to ensure safety and predictability.
 ## 2026-08-04 - [Grammatical Polish in Success Messages]
 **Learning:** Hardcoding plural strings (like "profile(s)") can lead to poor grammar when counts evaluate to exactly 1.
 **Action:** Use `pluralize` to dynamically correct grammar in CLI output to improve text polish and reduce cognitive load.
+
+## 2026-08-09 - [Grammatical Polish in Error Messages]
+**Learning:** Hardcoding generic plural strings (like "encountered errors") creates awkward grammar when there is exactly 1 error ("encountered 1 errors" or "encountered errors" for a single failure).
+**Action:** Use a dynamic pluralization helper (like `pluralize()`) and pass the actual count to explicitly format the string (e.g., "encountered 1 error" vs "encountered 2 errors") to ensure correct grammar and clarity in CLI output.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -299,3 +299,7 @@ context flags to ensure safety and predictability.
 ## 2026-08-09 - [Grammatical Polish in Error Messages]
 **Learning:** Hardcoding generic plural strings (like "encountered errors") creates awkward grammar when there is exactly 1 error ("encountered 1 errors" or "encountered errors" for a single failure).
 **Action:** Use a dynamic pluralization helper (like `pluralize()`) and pass the actual count to explicitly format the string (e.g., "encountered 1 error" vs "encountered 2 errors") to ensure correct grammar and clarity in CLI output.
+
+## 2026-08-09 - [Code Quality Metric Management in Hot Paths]
+**Learning:** Adding new UX conditional logic (like custom formatting, hints, or nuanced pluralizations) inside already long methods (like `main()`) increases cyclomatic complexity and logical density, which can trigger CodeScene or CI "Complex Method" violations and block PRs.
+**Action:** When injecting UX improvements into dense hot paths, proactively extract large, cohesive blocks of logic (such as a core loop body or `try/except` handler) into a separate helper function (e.g., `_sync_all_profiles`) to maintain a healthy code score while delivering the UX enhancement.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -307,3 +307,7 @@ context flags to ensure safety and predictability.
 ## 2026-08-09 - [Further Code Quality Optimization for Complex Methods]
 **Learning:** Extracting an entire outer loop into a separate function is not always enough to drop cyclomatic complexity to a passing threshold if the inner logic of the loop itself is still highly complex. In these cases, it is better to extract the logic *inside* the loop (e.g. processing a single profile) to completely flatten the method signature.
 **Action:** When remediating CodeScene "Complex Method" violations related to loop iteration, extract the core logic for processing a *single item* into a helper function (like `_process_single_profile`), rather than just extracting the whole loop block.
+
+## 2026-08-09 - [Optimizing Function Signatures for Code Health]
+**Learning:** Returning values (such as results or status objects) from helper functions is often cleaner and reduces the "Excess Number of Function Arguments" compared to passing a mutable data structure (like a list or dict) as an argument to be updated.
+**Action:** When extracting functions to improve code health, prefer returning results (e.g., `tuple[bool, SyncResult]`) rather than passing mutable collections as an argument to reduce argument count and side-effects.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -303,3 +303,7 @@ context flags to ensure safety and predictability.
 ## 2026-08-09 - [Code Quality Metric Management in Hot Paths]
 **Learning:** Adding new UX conditional logic (like custom formatting, hints, or nuanced pluralizations) inside already long methods (like `main()`) increases cyclomatic complexity and logical density, which can trigger CodeScene or CI "Complex Method" violations and block PRs.
 **Action:** When injecting UX improvements into dense hot paths, proactively extract large, cohesive blocks of logic (such as a core loop body or `try/except` handler) into a separate helper function (e.g., `_sync_all_profiles`) to maintain a healthy code score while delivering the UX enhancement.
+
+## 2026-08-09 - [Further Code Quality Optimization for Complex Methods]
+**Learning:** Extracting an entire outer loop into a separate function is not always enough to drop cyclomatic complexity to a passing threshold if the inner logic of the loop itself is still highly complex. In these cases, it is better to extract the logic *inside* the loop (e.g. processing a single profile) to completely flatten the method signature.
+**Action:** When remediating CodeScene "Complex Method" violations related to loop iteration, extract the core logic for processing a *single item* into a helper function (like `_process_single_profile`), rather than just extracting the whole loop block.

--- a/main.py
+++ b/main.py
@@ -499,11 +499,16 @@ def _print_dry_run_failure(error_count: int) -> None:
             f"{Colors.FAIL}⚠️  Dry run encountered {error_count} {error_word}. Please check the logs above.{Colors.ENDC}"
         )
     else:
-        print(f"⚠️  Dry run encountered {error_count} {error_word}. Please check the logs above.")
+        print(
+            f"⚠️  Dry run encountered {error_count} {error_word}. Please check the logs above."
+        )
 
 
 def _print_dry_run_next_steps(
-    args: argparse.Namespace, profile_ids: list[str], all_success: bool, error_count: int
+    args: argparse.Namespace,
+    profile_ids: list[str],
+    all_success: bool,
+    error_count: int,
 ) -> bool:
     """Prints suggested next steps after a dry run and handles interactive restart."""
     print()  # Spacer
@@ -583,6 +588,65 @@ def _apply_runtime_settings(cfg: dict[str, Any] | None) -> None:
         api_client.MAX_RETRIES = max_retries
 
 
+def _process_single_profile(
+    profile_id: str,
+    folder_urls: list[str],
+    args: argparse.Namespace,
+    plan: list[PlanEntry],
+    sync_results: list[SyncResult],
+) -> bool:
+    """Processes a single profile and updates the sync_results list."""
+    start_time = time.time()
+    # Skip validation for dry-run placeholder
+    if profile_id != "dry-run-placeholder" and not validate_profile_id(profile_id):
+        sync_results.append(
+            {
+                "profile": profile_id,
+                "folders": 0,
+                "rules": 0,
+                "status_label": "❌ Invalid Profile ID",
+                "success": False,
+                "duration": 0.0,
+            }
+        )
+        return False
+
+    display_profile = (
+        "(Unspecified)" if profile_id == "dry-run-placeholder" else profile_id
+    )
+    log.info("Starting sync for profile %s", display_profile)
+    status = sync_profile(
+        profile_id,
+        folder_urls,
+        token=TOKEN or "",
+        dry_run=args.dry_run,
+        no_delete=args.no_delete,
+        plan_accumulator=plan,
+    )
+    duration = time.time() - start_time
+
+    entry = next((p for p in plan if p["profile"] == profile_id), None)
+    folder_count = len(entry["folders"]) if entry else 0
+    rule_count = sum([f["rules"] for f in entry["folders"]]) if entry else 0
+
+    if args.dry_run:
+        status_text = "✅ Planned" if status else "❌ Failed (Dry)"
+    else:
+        status_text = "✅ Success" if status else "❌ Failed"
+
+    sync_results.append(
+        {
+            "profile": profile_id,
+            "folders": folder_count,
+            "rules": rule_count,
+            "status_label": status_text,
+            "success": status,
+            "duration": duration,
+        }
+    )
+    return status
+
+
 def _sync_all_profiles(
     profile_ids: list[str],
     folder_urls: list[str],
@@ -592,66 +656,16 @@ def _sync_all_profiles(
     """Runs the sync loop across all profiles, handling cancellation gracefully."""
     success_count = 0
     sync_results: list[SyncResult] = []
-
     profile_id = "unknown"
     start_time = time.time()
 
     try:
         for profile_id in profile_ids or ["dry-run-placeholder"]:
-            start_time = time.time()
-            # Skip validation for dry-run placeholder
-            if profile_id != "dry-run-placeholder" and not validate_profile_id(
-                profile_id
-            ):
-                sync_results.append(
-                    {
-                        "profile": profile_id,
-                        "folders": 0,
-                        "rules": 0,
-                        "status_label": "❌ Invalid Profile ID",
-                        "success": False,
-                        "duration": 0.0,
-                    }
-                )
-                continue
-
-            display_profile = (
-                "(Unspecified)" if profile_id == "dry-run-placeholder" else profile_id
+            status = _process_single_profile(
+                profile_id, folder_urls, args, plan, sync_results
             )
-            log.info("Starting sync for profile %s", display_profile)
-            status = sync_profile(
-                profile_id,
-                folder_urls,
-                token=TOKEN or "",
-                dry_run=args.dry_run,
-                no_delete=args.no_delete,
-                plan_accumulator=plan,
-            )
-            end_time = time.time()
-            duration = end_time - start_time
-
             if status:
                 success_count += 1
-
-            entry = next((p for p in plan if p["profile"] == profile_id), None)
-            folder_count = len(entry["folders"]) if entry else 0
-            rule_count = sum([f["rules"] for f in entry["folders"]]) if entry else 0
-
-            if args.dry_run:
-                status_text = "✅ Planned" if status else "❌ Failed (Dry)"
-            else:
-                status_text = "✅ Success" if status else "❌ Failed"
-
-            sync_results.append(
-                {
-                    "profile": profile_id,
-                    "folders": folder_count,
-                    "rules": rule_count,
-                    "status_label": status_text,
-                    "success": status,
-                    "duration": duration,
-                }
-            )
     except KeyboardInterrupt:
         duration = time.time() - start_time
         _clear_current_line()
@@ -743,7 +757,9 @@ def main() -> bool:
     warm_up_cache(folder_urls)
 
     plan: list[PlanEntry] = []
-    success_count, sync_results = _sync_all_profiles(profile_ids, folder_urls, args, plan)
+    success_count, sync_results = _sync_all_profiles(
+        profile_ids, folder_urls, args, plan
+    )
 
     if args.plan_json:
         with open(args.plan_json, "w", encoding="utf-8") as f:
@@ -765,7 +781,9 @@ def main() -> bool:
         print_success_message(profile_ids, success_count, total)
 
     # Dry Run Next Steps
-    if args.dry_run and _print_dry_run_next_steps(args, profile_ids, all_success, total - success_count):
+    if args.dry_run and _print_dry_run_next_steps(
+        args, profile_ids, all_success, total - success_count
+    ):
         return True
 
     # Display execution statistics and rate limit status

--- a/main.py
+++ b/main.py
@@ -593,23 +593,19 @@ def _process_single_profile(
     folder_urls: list[str],
     args: argparse.Namespace,
     plan: list[PlanEntry],
-    sync_results: list[SyncResult],
-) -> bool:
-    """Processes a single profile and updates the sync_results list."""
+) -> tuple[bool, SyncResult]:
+    """Processes a single profile and returns its status and result."""
     start_time = time.time()
     # Skip validation for dry-run placeholder
     if profile_id != "dry-run-placeholder" and not validate_profile_id(profile_id):
-        sync_results.append(
-            {
-                "profile": profile_id,
-                "folders": 0,
-                "rules": 0,
-                "status_label": "❌ Invalid Profile ID",
-                "success": False,
-                "duration": 0.0,
-            }
-        )
-        return False
+        return False, {
+            "profile": profile_id,
+            "folders": 0,
+            "rules": 0,
+            "status_label": "❌ Invalid Profile ID",
+            "success": False,
+            "duration": 0.0,
+        }
 
     display_profile = (
         "(Unspecified)" if profile_id == "dry-run-placeholder" else profile_id
@@ -634,17 +630,14 @@ def _process_single_profile(
     else:
         status_text = "✅ Success" if status else "❌ Failed"
 
-    sync_results.append(
-        {
-            "profile": profile_id,
-            "folders": folder_count,
-            "rules": rule_count,
-            "status_label": status_text,
-            "success": status,
-            "duration": duration,
-        }
-    )
-    return status
+    return status, {
+        "profile": profile_id,
+        "folders": folder_count,
+        "rules": rule_count,
+        "status_label": status_text,
+        "success": status,
+        "duration": duration,
+    }
 
 
 def _sync_all_profiles(
@@ -661,9 +654,10 @@ def _sync_all_profiles(
 
     try:
         for profile_id in profile_ids or ["dry-run-placeholder"]:
-            status = _process_single_profile(
-                profile_id, folder_urls, args, plan, sync_results
+            status, result = _process_single_profile(
+                profile_id, folder_urls, args, plan
             )
+            sync_results.append(result)
             if status:
                 success_count += 1
     except KeyboardInterrupt:

--- a/main.py
+++ b/main.py
@@ -753,7 +753,10 @@ def main() -> bool:
         print_success_message(profile_ids, success_count, total)
 
     # Dry Run Next Steps
-    if args.dry_run and _print_dry_run_next_steps(args, profile_ids, all_success, total - success_count):
+    dry_run_error_count = sum(1 for result in sync_results if not result["success"])
+    if args.dry_run and _print_dry_run_next_steps(
+        args, profile_ids, all_success, dry_run_error_count
+    ):
         return True
 
     # Display execution statistics and rate limit status

--- a/main.py
+++ b/main.py
@@ -491,23 +491,24 @@ def _print_dry_run_success(cmd_str: str) -> None:
         print(f"   {cmd_str}")
 
 
-def _print_dry_run_failure() -> None:
+def _print_dry_run_failure(error_count: int) -> None:
     """Prints dry run error message."""
+    error_word = pluralize(error_count, "error")
     if USE_COLORS:
         print(
-            f"{Colors.FAIL}⚠️  Dry run encountered errors. Please check the logs above.{Colors.ENDC}"
+            f"{Colors.FAIL}⚠️  Dry run encountered {error_count} {error_word}. Please check the logs above.{Colors.ENDC}"
         )
     else:
-        print("⚠️  Dry run encountered errors. Please check the logs above.")
+        print(f"⚠️  Dry run encountered {error_count} {error_word}. Please check the logs above.")
 
 
 def _print_dry_run_next_steps(
-    args: argparse.Namespace, profile_ids: list[str], all_success: bool
+    args: argparse.Namespace, profile_ids: list[str], all_success: bool, error_count: int
 ) -> bool:
     """Prints suggested next steps after a dry run and handles interactive restart."""
     print()  # Spacer
     if not all_success:
-        _print_dry_run_failure()
+        _print_dry_run_failure(error_count)
         return False
 
     cmd_str = _build_dry_run_command_str(args, profile_ids)
@@ -752,7 +753,7 @@ def main() -> bool:
         print_success_message(profile_ids, success_count, total)
 
     # Dry Run Next Steps
-    if args.dry_run and _print_dry_run_next_steps(args, profile_ids, all_success):
+    if args.dry_run and _print_dry_run_next_steps(args, profile_ids, all_success, total - success_count):
         return True
 
     # Display execution statistics and rate limit status

--- a/main.py
+++ b/main.py
@@ -583,71 +583,13 @@ def _apply_runtime_settings(cfg: dict[str, Any] | None) -> None:
         api_client.MAX_RETRIES = max_retries
 
 
-def main() -> bool:
-    """
-    Main entry point for Control D Sync.
-
-    Loads environment configuration, validates inputs, warms up cache,
-    and syncs profiles. Supports interactive prompts for missing credentials
-    when running in a TTY. Prints summary statistics and exits with appropriate
-    status code.
-    """
-    # SECURITY: Check .env permissions (after Colors is defined for NO_COLOR support)
-    # This must happen BEFORE load_dotenv() to prevent reading secrets from world-readable files
-    check_env_permissions()
-    load_dotenv()
-
-    global TOKEN
-    # Re-initialize TOKEN to pick up values from .env (since load_dotenv was delayed)
-    TOKEN = _clean_env_kv(os.getenv("TOKEN"), "TOKEN")
-
-    # Inject token-aware sanitizer into modules that must not log secrets.
-    api_client._sanitize_fn = validation.sanitize_for_log
-    cache._sanitize_fn = validation.sanitize_for_log
-    set_token_for_redaction(TOKEN or "")
-
-    args = parse_args()
-
-    # Load persistent cache from disk (graceful degradation on any error)
-    # NOTE: Called only after successful argument parsing so that `--help` or
-    #       argument errors do not perform unnecessary filesystem I/O or logging.
-    load_disk_cache()
-
-    # Handle --clear-cache: delete cache file and exit immediately
-    if args.clear_cache:
-        _handle_clear_cache()
-
-    profiles_arg = (
-        _clean_env_kv(args.profiles or os.getenv("PROFILE", ""), "PROFILE") or ""
-    )
-    profile_ids = [extract_profile_id(p) for p in profiles_arg.split(",") if p.strip()]
-
-    # --folder-url flags take highest precedence; otherwise use config file or defaults
-    folder_urls, cfg = _resolve_folder_urls(args)
-
-    if cfg is not None:
-        _apply_runtime_settings(cfg)
-
-    # Interactive prompts for missing config
-    if not args.dry_run and sys.stdin.isatty():
-        _prompt_for_missing_config(profile_ids)
-
-    # Re-apply token redaction in case the interactive prompt changed TOKEN.
-    set_token_for_redaction(TOKEN or "")
-
-    if not profile_ids and not args.dry_run:
-        log.error(
-            "PROFILE missing and --dry-run not set. Provide --profiles or set PROFILE env."
-        )
-        exit(1)
-
-    if not TOKEN and not args.dry_run:
-        log.error("TOKEN missing and --dry-run not set. Set TOKEN env for live sync.")
-        exit(1)
-
-    warm_up_cache(folder_urls)
-
-    plan: list[PlanEntry] = []
+def _sync_all_profiles(
+    profile_ids: list[str],
+    folder_urls: list[str],
+    args: argparse.Namespace,
+    plan: list[PlanEntry],
+) -> tuple[int, list[SyncResult]]:
+    """Runs the sync loop across all profiles, handling cancellation gracefully."""
     success_count = 0
     sync_results: list[SyncResult] = []
 
@@ -733,6 +675,76 @@ def main() -> bool:
             }
         )
 
+    return success_count, sync_results
+
+
+def main() -> bool:
+    """
+    Main entry point for Control D Sync.
+
+    Loads environment configuration, validates inputs, warms up cache,
+    and syncs profiles. Supports interactive prompts for missing credentials
+    when running in a TTY. Prints summary statistics and exits with appropriate
+    status code.
+    """
+    # SECURITY: Check .env permissions (after Colors is defined for NO_COLOR support)
+    # This must happen BEFORE load_dotenv() to prevent reading secrets from world-readable files
+    check_env_permissions()
+    load_dotenv()
+
+    global TOKEN
+    # Re-initialize TOKEN to pick up values from .env (since load_dotenv was delayed)
+    TOKEN = _clean_env_kv(os.getenv("TOKEN"), "TOKEN")
+
+    # Inject token-aware sanitizer into modules that must not log secrets.
+    api_client._sanitize_fn = validation.sanitize_for_log
+    cache._sanitize_fn = validation.sanitize_for_log
+    set_token_for_redaction(TOKEN or "")
+
+    args = parse_args()
+
+    # Load persistent cache from disk (graceful degradation on any error)
+    # NOTE: Called only after successful argument parsing so that `--help` or
+    #       argument errors do not perform unnecessary filesystem I/O or logging.
+    load_disk_cache()
+
+    # Handle --clear-cache: delete cache file and exit immediately
+    if args.clear_cache:
+        _handle_clear_cache()
+
+    profiles_arg = (
+        _clean_env_kv(args.profiles or os.getenv("PROFILE", ""), "PROFILE") or ""
+    )
+    profile_ids = [extract_profile_id(p) for p in profiles_arg.split(",") if p.strip()]
+
+    # --folder-url flags take highest precedence; otherwise use config file or defaults
+    folder_urls, cfg = _resolve_folder_urls(args)
+
+    if cfg is not None:
+        _apply_runtime_settings(cfg)
+
+    # Interactive prompts for missing config
+    if not args.dry_run and sys.stdin.isatty():
+        _prompt_for_missing_config(profile_ids)
+
+    # Re-apply token redaction in case the interactive prompt changed TOKEN.
+    set_token_for_redaction(TOKEN or "")
+
+    if not profile_ids and not args.dry_run:
+        log.error(
+            "PROFILE missing and --dry-run not set. Provide --profiles or set PROFILE env."
+        )
+        exit(1)
+
+    if not TOKEN and not args.dry_run:
+        log.error("TOKEN missing and --dry-run not set. Set TOKEN env for live sync.")
+        exit(1)
+
+    warm_up_cache(folder_urls)
+
+    plan: list[PlanEntry] = []
+    success_count, sync_results = _sync_all_profiles(profile_ids, folder_urls, args, plan)
+
     if args.plan_json:
         with open(args.plan_json, "w", encoding="utf-8") as f:
             json.dump(plan, f, indent=2)
@@ -753,10 +765,7 @@ def main() -> bool:
         print_success_message(profile_ids, success_count, total)
 
     # Dry Run Next Steps
-    dry_run_error_count = sum(1 for result in sync_results if not result["success"])
-    if args.dry_run and _print_dry_run_next_steps(
-        args, profile_ids, all_success, dry_run_error_count
-    ):
+    if args.dry_run and _print_dry_run_next_steps(args, profile_ids, all_success, total - success_count):
         return True
 
     # Display execution statistics and rate limit status


### PR DESCRIPTION
What: Pluralized dry run errors
Why: To improve grammatical polish and prevent hardcoded generic plurals when error_count == 1
Before: 'Dry run encountered errors.'
After: 'Dry run encountered 1 error.' (or 'X errors')

---
*PR created automatically by Jules for task [10568972526569294480](https://jules.google.com/task/10568972526569294480) started by @abhimehro*